### PR TITLE
Fix build script exit code

### DIFF
--- a/build-manifests.sh
+++ b/build-manifests.sh
@@ -4,6 +4,7 @@ main() {
     local dirs
     dirs=($(find . -name kustomization.y?ml -printf "%h\n"))
     local out=auto-generated
+    local ret=0
     rm -rf "$out"
     mkdir -p "$out"
 
@@ -12,8 +13,11 @@ main() {
         mkdir -p "$o"
         if ! kustomize build -o "$o" "$d"; then
             echo "failed to build $d" >&2
+            ret=1
         fi
     done
+
+    exit "$ret"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then


### PR DESCRIPTION
If one of the kustomization directories failed to be build, the script should end with an error.