### PR TITLE
RHTAP-1201: External secrets for consoledot tests

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/gbenhaim-tenant/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/gbenhaim-tenant/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: app-interface
+  namespace: gbenhaim-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: app-interface
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: app-interface

--- a/auto-generated/cluster/stone-prd-rh01/gbenhaim-tenant/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/gbenhaim-tenant/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: consoledot-ephemeral-env-provider
+  namespace: gbenhaim-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: consoledot-ephemeral-env-provider
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ephemeral-env-provider

--- a/auto-generated/cluster/stone-prd-rh01/gbenhaim-tenant/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/gbenhaim-tenant/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: rh-artifacts-bucket-writer
+  namespace: gbenhaim-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: ""
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: rh-artifacts-bucket-writer-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rh-artifacts-bucket

--- a/auto-generated/lib/app-interface/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
+++ b/auto-generated/lib/app-interface/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: app-interface
+spec:
+  dataFrom:
+  - extract:
+      key: app-interface
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: app-interface

--- a/auto-generated/lib/consoledot-ephemeral-env-provider/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
+++ b/auto-generated/lib/consoledot-ephemeral-env-provider/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: consoledot-ephemeral-env-provider
+spec:
+  dataFrom:
+  - extract:
+      key: consoledot-ephemeral-env-provider
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ephemeral-env-provider

--- a/auto-generated/lib/consoledot-test-pipeline/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
+++ b/auto-generated/lib/consoledot-test-pipeline/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: app-interface
+spec:
+  dataFrom:
+  - extract:
+      key: app-interface
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: app-interface

--- a/auto-generated/lib/consoledot-test-pipeline/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
+++ b/auto-generated/lib/consoledot-test-pipeline/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: consoledot-ephemeral-env-provider
+spec:
+  dataFrom:
+  - extract:
+      key: consoledot-ephemeral-env-provider
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ephemeral-env-provider

--- a/auto-generated/lib/consoledot-test-pipeline/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
+++ b/auto-generated/lib/consoledot-test-pipeline/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: rh-artifacts-bucket-writer
+spec:
+  dataFrom:
+  - extract:
+      key: ""
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: rh-artifacts-bucket-writer-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rh-artifacts-bucket

--- a/auto-generated/lib/rh-artifacts-bucket-writer/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
+++ b/auto-generated/lib/rh-artifacts-bucket-writer/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: rh-artifacts-bucket-writer
+spec:
+  dataFrom:
+  - extract:
+      key: ""
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: rh-artifacts-bucket-writer-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rh-artifacts-bucket

--- a/cluster/stone-prd-rh01/gbenhaim-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/gbenhaim-tenant/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ccx-integ-test.yaml
+  - ../../../lib/consoledot-test-pipeline
 namespace: gbenhaim-tenant

--- a/lib/app-interface/app-interface.yaml
+++ b/lib/app-interface/app-interface.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-interface
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: app-interface
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: app-interface

--- a/lib/app-interface/kustomization.yaml
+++ b/lib/app-interface/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app-interface.yaml

--- a/lib/consoledot-ephemeral-env-provider/consoledot-ephemeral-env-provider.yaml
+++ b/lib/consoledot-ephemeral-env-provider/consoledot-ephemeral-env-provider.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: consoledot-ephemeral-env-provider
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: consoledot-ephemeral-env-provider
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ephemeral-env-provider

--- a/lib/consoledot-ephemeral-env-provider/kustomization.yaml
+++ b/lib/consoledot-ephemeral-env-provider/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - consoledot-ephemeral-env-provider.yaml

--- a/lib/consoledot-test-pipeline/kustomization.yaml
+++ b/lib/consoledot-test-pipeline/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../app-interface
+  - ../consoledot-ephemeral-env-provider
+  - ../rh-artifacts-bucket-writer

--- a/lib/rh-artifacts-bucket-writer/kustomization.yaml
+++ b/lib/rh-artifacts-bucket-writer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rh-artifacts-bucket-writer.yaml

--- a/lib/rh-artifacts-bucket-writer/rh-artifacts-bucket-writer.yaml
+++ b/lib/rh-artifacts-bucket-writer/rh-artifacts-bucket-writer.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rh-artifacts-bucket-writer
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: ""
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: rh-artifacts-bucket-writer-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rh-artifacts-bucket


### PR DESCRIPTION
The the required external secrets for running the tests of the different consoledot tenants.
depends on https://github.com/redhat-appstudio/infra-deployments/pull/2333