### PR TITLE
Add SAs and Bindings for managed tenants

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/rbac.authorization.k8s.io_v1_rolebinding_cnv-fbc-tenant-release-service-pipeline-rolebinding-dev.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/rbac.authorization.k8s.io_v1_rolebinding_cnv-fbc-tenant-release-service-pipeline-rolebinding-dev.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnv-fbc-tenant-release-service-pipeline-rolebinding-dev
+  namespace: rh-managed-cnv-fbc-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: release-service-account
+  namespace: rh-managed-cnv-fbc-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/rbac.authorization.k8s.io_v1_rolebinding_cnv-fbc-tenant-release-service-pipeline-rolebinding-managed.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/rbac.authorization.k8s.io_v1_rolebinding_cnv-fbc-tenant-release-service-pipeline-rolebinding-managed.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnv-fbc-tenant-release-service-pipeline-rolebinding-managed
+  namespace: rh-managed-cnv-fbc-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: release-service-account
+  namespace: rh-managed-cnv-fbc-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/v1_serviceaccount_release-service-account.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/v1_serviceaccount_release-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-service-account
+  namespace: rh-managed-cnv-fbc-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/rbac.authorization.k8s.io_v1_rolebinding_crt-redhat-acm-tenant-release-service-pipeline-rolebinding-dev.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/rbac.authorization.k8s.io_v1_rolebinding_crt-redhat-acm-tenant-release-service-pipeline-rolebinding-dev.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: crt-redhat-acm-tenant-release-service-pipeline-rolebinding-dev
+  namespace: rh-managed-red-hat-acm-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: release-service-account
+  namespace: rh-managed-red-hat-acm-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/rbac.authorization.k8s.io_v1_rolebinding_crt-redhat-acm-tenant-release-service-pipeline-rolebinding-managed.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/rbac.authorization.k8s.io_v1_rolebinding_crt-redhat-acm-tenant-release-service-pipeline-rolebinding-managed.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: crt-redhat-acm-tenant-release-service-pipeline-rolebinding-managed
+  namespace: rh-managed-red-hat-acm-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: release-service-account
+  namespace: rh-managed-red-hat-acm-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/v1_serviceaccount_release-service-account.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/v1_serviceaccount_release-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-service-account
+  namespace: rh-managed-red-hat-acm-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/kustomization.yaml
@@ -5,4 +5,6 @@ resources:
   - persistent_volume_claim.yaml
   - release_plan_admission.yaml
   - release_strategy.yaml
+  - release-pipeline-sa.yaml
+  - release-service-account-build-rb.yaml
 namespace: rh-managed-cnv-fbc-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/release-pipeline-sa.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/release-pipeline-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-service-account
+  namespace: rh-managed-cnv-fbc-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/release-service-account-build-rb.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/release-service-account-build-rb.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnv-fbc-tenant-release-service-pipeline-rolebinding-dev
+  namespace: cnv-fbc-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: release-service-account
+    namespace: rh-managed-cnv-fbc-tenant
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnv-fbc-tenant-release-service-pipeline-rolebinding-managed
+  namespace: rh-managed-cnv-fbc-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: release-service-account
+    namespace: rh-managed-cnv-fbc-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/kustomization.yaml
@@ -5,4 +5,6 @@ resources:
   - ec-policy.yaml
   - release_plan_admission.yaml
   - release_strategy.yaml
+  - release-pipeline-sa.yaml
+  - release-service-account-build-rb.yaml
 namespace: rh-managed-red-hat-acm-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/release-pipeline-sa.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/release-pipeline-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-service-account
+  namespace: rh-managed-red-hat-acm-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/release-service-account-build-rb.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/release-service-account-build-rb.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: crt-redhat-acm-tenant-release-service-pipeline-rolebinding-dev
+  namespace: crt-redhat-acm-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: release-service-account
+    namespace: rh-managed-red-hat-acm-tenant
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: crt-redhat-acm-tenant-release-service-pipeline-rolebinding-managed
+  namespace: rh-managed-red-hat-acm-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: release-service-account
+    namespace: rh-managed-red-hat-acm-tenant


### PR DESCRIPTION
- release pipeline service accounts in managed workspaces need access to release type CRs