### PR TITLE
Make build-manifests script compatible with Mac

### DIFF
--- a/build-manifests.sh
+++ b/build-manifests.sh
@@ -2,7 +2,7 @@
 
 main() {
     local dirs
-    dirs=($(find . -name kustomization.y?ml -printf "%h\n"))
+    dirs=($(find . -name kustomization.y?ml | xargs dirname))
     local out=auto-generated
     local ret=0
     rm -rf "$out"


### PR DESCRIPTION
Since the -printf argument in find is not compatible with Mac, we get the directories with dirname instead