### PR TITLE
Add compatibility with .yml and cleaner output

### DIFF
--- a/build-manifests.sh
+++ b/build-manifests.sh
@@ -1,14 +1,15 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 main() {
     local dirs
-    dirs=($(find . -name kustomization.y?ml | xargs dirname))
+    dirs=($(find . \( -name 'kustomization.yaml' -o -name 'kustomization.yml' \) | xargs dirname))
     local out=auto-generated
     local ret=0
     rm -rf "$out"
     mkdir -p "$out"
 
     for d in "${dirs[@]}"; do
+        echo "Checking directory ${d}"
         o="${out}/${d}"
         mkdir -p "$o"
         if ! kustomize build -o "$o" "$d"; then


### PR DESCRIPTION
- Add compatibility with kustomization.yml instead of kustomization.yaml
- Clean the output of the build manifests to make it more user-friendly