### PR TITLE
RHTAPREL-435: new workspaces for rhtap

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: rh-policy
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  configuration:
+    exclude:
+    - hermetic_build_task
+    - step_image_registries
+    - tasks.required_tasks_found:prefetch-dependencies
+    include:
+    - '@redhat'
+  description: Includes rules for levels 1, 2 & 3 of SLSA v0.1.
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+  - data:
+    - github.com/enterprise-contract/ec-policies//data
+    name: Default
+    policy:
+    - github.com/enterprise-contract/ec-policies//policy/lib
+    - github.com/enterprise-contract/ec-policies//policy/release

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-rpa.yaml
@@ -1,0 +1,17 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: rhtap-build-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  application: build
+  displayName: ""
+  extraData:
+    infra-deployment-update-script: |
+      sed -i -e 's|\(https://github.com/redhat-appstudio/image-controller/.*?ref=\)\(.*\)|\1{{ revision }} |' -e 's/\(newTag: \).*/\1{{ revision }}/' components/image-controller/base/kustomization.yaml
+    slack-webhook-notification-secret-keyname: build
+  origin: rhtap-build-tenant
+  releaseStrategy: rhtap-service-push-strategy

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-external-secrets-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-external-secrets-rpa.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+  name: rhtap-external-secrets-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  application: external-secrets
+  displayName: ""
+  origin: rhtap-gitops-tenant
+  releaseStrategy: rhtap-service-push-strategy

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releasestrategy_push-to-external-registry-strategy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releasestrategy_push-to-external-registry-strategy.yaml
@@ -1,0 +1,25 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseStrategy
+metadata:
+  name: push-to-external-registry-strategy
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  bundle: quay.io/hacbs-release/pipeline-push-to-external-registry:main
+  params:
+  - name: extraConfigGitUrl
+    value: https://github.com/hacbs-release/strategy-configs.git
+  - name: extraConfigPath
+    value: rhtap.yaml
+  - name: extraConfigRevision
+    value: main
+  - name: pyxisServerType
+    value: stage
+  - name: pyxisSecret
+    value: pyxis
+  - name: tag
+    value: latest
+  - name: addGitShaTag
+    value: "true"
+  pipeline: push-to-external-registry
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releasestrategy_rhtap-service-push-strategy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releasestrategy_rhtap-service-push-strategy.yaml
@@ -1,0 +1,25 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseStrategy
+metadata:
+  name: rhtap-service-push-strategy
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  bundle: quay.io/hacbs-release/pipeline-rhtap-service-push:main
+  params:
+  - name: extraConfigGitUrl
+    value: https://github.com/hacbs-release/strategy-configs.git
+  - name: extraConfigPath
+    value: rhtap.yaml
+  - name: extraConfigRevision
+    value: main
+  - name: pyxisServerType
+    value: stage
+  - name: pyxisSecret
+    value: pyxis-staging-secret
+  - name: tag
+    value: latest
+  - name: addGitShaTag
+    value: "true"
+  pipeline: rhtap-service-push
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1beta1_remotesecret_infra-deployments-pr-creator-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1beta1_remotesecret_infra-deployments-pr-creator-remote-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: infra-deployments-pr-creator-remote-secret
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  secret:
+    linkedTo:
+    - serviceAccount:
+        reference:
+          name: rh-managed-rhtap-ser-tenant
+    name: infra-deployments-pr-creator
+    type: Opaque
+  targets:
+  - namespace: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1beta1_remotesecret_pyxis-staging-secret-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1beta1_remotesecret_pyxis-staging-secret-remote-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: pyxis-staging-secret-remote-secret
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  secret:
+    linkedTo:
+    - serviceAccount:
+        reference:
+          name: rh-managed-rhtap-ser-tenant
+    name: pyxis-staging-secret
+    type: Opaque
+  targets:
+  - namespace: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1beta1_remotesecret_slack-webhook-notification-secret-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1beta1_remotesecret_slack-webhook-notification-secret-remote-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: slack-webhook-notification-secret-remote-secret
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  secret:
+    linkedTo:
+    - serviceAccount:
+        reference:
+          name: rh-managed-rhtap-ser-tenant
+    name: slack-webhook-notification-secret
+    type: Opaque
+  targets:
+  - namespace: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/rbac.authorization.k8s.io_v1_rolebinding_rhtap-build-tenant-release-service-pipeline-rolebinding-managed.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/rbac.authorization.k8s.io_v1_rolebinding_rhtap-build-tenant-release-service-pipeline-rolebinding-managed.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhtap-build-tenant-release-service-pipeline-rolebinding-managed
+  namespace: rh-managed-rhtap-ser-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: rhtap-servicerelease-sa
+  namespace: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/rbac.authorization.k8s.io_v1_rolebinding_rhtap-gitops-tenant-release-service-pipeline-rolebinding-managed.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/rbac.authorization.k8s.io_v1_rolebinding_rhtap-gitops-tenant-release-service-pipeline-rolebinding-managed.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhtap-gitops-tenant-release-service-pipeline-rolebinding-managed
+  namespace: rh-managed-rhtap-ser-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: rhtap-servicerelease-sa
+  namespace: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/appstudio.redhat.com_v1beta1_remotesecret_infra-deployments-pr-creator-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/appstudio.redhat.com_v1beta1_remotesecret_infra-deployments-pr-creator-remote-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: infra-deployments-pr-creator-remote-secret
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  secret:
+    linkedTo:
+    - serviceAccount:
+        reference:
+          name: rh-managed-rhtap-ser-tenant
+    name: infra-deployments-pr-creator
+    type: Opaque
+  targets:
+  - namespace: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/appstudio.redhat.com_v1beta1_remotesecret_pyxis-staging-secret-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/appstudio.redhat.com_v1beta1_remotesecret_pyxis-staging-secret-remote-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: pyxis-staging-secret-remote-secret
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  secret:
+    linkedTo:
+    - serviceAccount:
+        reference:
+          name: rh-managed-rhtap-ser-tenant
+    name: pyxis-staging-secret
+    type: Opaque
+  targets:
+  - namespace: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/appstudio.redhat.com_v1beta1_remotesecret_slack-webhook-notification-secret-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/appstudio.redhat.com_v1beta1_remotesecret_slack-webhook-notification-secret-remote-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: slack-webhook-notification-secret-remote-secret
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  secret:
+    linkedTo:
+    - serviceAccount:
+        reference:
+          name: rh-managed-rhtap-ser-tenant
+    name: slack-webhook-notification-secret
+    type: Opaque
+  targets:
+  - namespace: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/v1_persistentvolumeclaim_release-pvc.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/v1_persistentvolumeclaim_release-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: release-pvc
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/v1_serviceaccount_rhtap-servicerelease-sa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/v1_serviceaccount_rhtap-servicerelease-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhtap-servicerelease-sa
+  namespace: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-to-quay-rhtap-ser.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: release-to-quay-rhtap-ser
+  namespace: rhtap-build-tenant
+spec:
+  application: build
+  displayName: build release-to-quay
+  target: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets.io_v1beta1_externalsecret_infra-deployments-pr-creator.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets.io_v1beta1_externalsecret_infra-deployments-pr-creator.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: infra-deployments-pr-creator
+  namespace: rhtap-build-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: production/build/tekton-ci/infra-deployments-pr-creator
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: infra-deployments-pr-creator

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/external-secrets.io_v1beta1_externalsecret_infra-deployments-pr-creator.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/external-secrets.io_v1beta1_externalsecret_infra-deployments-pr-creator.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: infra-deployments-pr-creator
+  namespace: rhtap-build-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: production/build/tekton-ci/infra-deployments-pr-creator
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: infra-deployments-pr-creator

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-to-quay-rhtap-ser.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: release-to-quay-rhtap-ser
+  namespace: rhtap-gitops-tenant
+spec:
+  application: external-secrets
+  displayName: external-secrets release-to-quay
+  target: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: rh-policy
+spec:
+  configuration:
+    exclude:
+      - hermetic_build_task # Change policy definition once https://issues.redhat.com/browse/HACBS-2657 is implemented
+      - step_image_registries
+      - tasks.required_tasks_found:prefetch-dependencies # prefetch is not required
+    include:
+      - '@redhat'
+  description: 'Includes rules for levels 1, 2 & 3 of SLSA v0.1.'
+  publicKey: 'k8s://openshift-pipelines/public-key'
+  sources:
+    - data:
+        - github.com/enterprise-contract/ec-policies//data
+      name: Default
+      policy:
+        - github.com/enterprise-contract/ec-policies//policy/lib
+        - github.com/enterprise-contract/ec-policies//policy/release

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+- release_plan_admission-build.yaml
+- release_plan_admission-external-secrets.yaml
+- release-service-account-build-rb.yaml
+- release-service-account-external-secrets-rb.yaml
+- ec-policy.yaml
+- release-strategy.yaml
+- persistent-volume-claim.yaml
+- release-pipeline-sa.yaml
+- remote-secrets
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/persistent-volume-claim.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/persistent-volume-claim.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: release-pvc
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release-pipeline-sa.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release-pipeline-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhtap-servicerelease-sa
+  namespace: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release-service-account-build-rb.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release-service-account-build-rb.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhtap-build-tenant-release-service-pipeline-rolebinding-managed
+  namespace: rh-managed-rhtap-ser-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: rhtap-servicerelease-sa
+    namespace: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release-service-account-external-secrets-rb.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release-service-account-external-secrets-rb.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhtap-gitops-tenant-release-service-pipeline-rolebinding-managed
+  namespace: rh-managed-rhtap-ser-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: rhtap-servicerelease-sa
+    namespace: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release-strategy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release-strategy.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseStrategy
+metadata:
+  name: push-to-external-registry-strategy
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  bundle: 'quay.io/hacbs-release/pipeline-push-to-external-registry:main'
+  params:
+    - name: extraConfigGitUrl
+      value: 'https://github.com/hacbs-release/strategy-configs.git'
+    - name: extraConfigPath
+      value: rhtap.yaml
+    - name: extraConfigRevision
+      value: main
+    - name: pyxisServerType
+      value: stage
+    - name: pyxisSecret
+      value: pyxis
+    - name: tag
+      value: latest
+    - name: addGitShaTag
+      value: 'true'
+  pipeline: push-to-external-registry
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseStrategy
+metadata:
+  name: rhtap-service-push-strategy
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  bundle: 'quay.io/hacbs-release/pipeline-rhtap-service-push:main'
+  params:
+    - name: extraConfigGitUrl
+      value: 'https://github.com/hacbs-release/strategy-configs.git'
+    - name: extraConfigPath
+      value: rhtap.yaml
+    - name: extraConfigRevision
+      value: main
+    - name: pyxisServerType
+      value: stage
+    - name: pyxisSecret
+      value: pyxis-staging-secret
+    - name: tag
+      value: latest
+    - name: addGitShaTag
+      value: 'true'
+  pipeline: rhtap-service-push
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-build.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-build.yaml
@@ -1,0 +1,18 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: rhtap-build-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  application: build
+  displayName: ''
+  origin: rhtap-build-tenant
+  releaseStrategy: rhtap-service-push-strategy
+  extraData:
+    infra-deployment-update-script: >
+      sed -i -e 's|\(https://github.com/redhat-appstudio/image-controller/.*?ref=\)\(.*\)|\1{{ revision }}
+      |' -e 's/\(newTag: \).*/\1{{ revision }}/' components/image-controller/base/kustomization.yaml
+    slack-webhook-notification-secret-keyname: "build"

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-external-secrets.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-external-secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: rhtap-external-secrets-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+spec:
+  application: external-secrets
+  displayName: ''
+  origin: rhtap-gitops-tenant
+  releaseStrategy: rhtap-service-push-strategy

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - remote_secret-infra-deployments-pr-creator.yaml
+  - remote_secret-slack-webhook-notification.yaml
+  - remote_secret-pyxis-secret.yaml
+namespace: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/remote_secret-infra-deployments-pr-creator.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/remote_secret-infra-deployments-pr-creator.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: infra-deployments-pr-creator-remote-secret
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  secret:
+    name: infra-deployments-pr-creator
+    type: Opaque
+    linkedTo:
+      - serviceAccount:
+          reference:
+            name: rh-managed-rhtap-ser-tenant
+  targets:
+    - namespace: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/remote_secret-pyxis-secret.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/remote_secret-pyxis-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: pyxis-staging-secret-remote-secret
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  secret:
+    name: pyxis-staging-secret
+    type: Opaque
+    linkedTo:
+      - serviceAccount:
+          reference:
+            name: rh-managed-rhtap-ser-tenant
+  targets:
+    - namespace: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/remote_secret-slack-webhook-notification.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/remote-secrets/remote_secret-slack-webhook-notification.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: slack-webhook-notification-secret-remote-secret
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  secret:
+    name: slack-webhook-notification-secret
+    type: Opaque
+    linkedTo:
+      - serviceAccount:
+          reference:
+            name: rh-managed-rhtap-ser-tenant
+  targets:
+    - namespace: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/infra-deployments-pr-creator.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/infra-deployments-pr-creator.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: infra-deployments-pr-creator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/tekton-ci/infra-deployments-pr-creator
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: infra-deployments-pr-creator

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- infra-deployments-pr-creator.yaml
+namespace: rhtap-build-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- release_plan.yaml
+- external-secrets
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: release-to-quay-rhtap-ser
+  namespace: rhtap-build-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  application: build
+  displayName: build release-to-quay
+  target: rh-managed-rhtap-ser-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- release_plan.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/release_plan.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: release-to-quay-rhtap-ser
+  namespace: rhtap-gitops-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  application: external-secrets
+  displayName: external-secrets release-to-quay
+  target: rh-managed-rhtap-ser-tenant


### PR DESCRIPTION
- migrate to use correct name for managed workspace
- migrate build and gitops tenants
- add RemoteSecrets