### PR TITLE
Fix rh release strategy

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_releasestrategy_push-to-external-registry-strategy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_releasestrategy_push-to-external-registry-strategy.yaml
@@ -4,7 +4,6 @@ metadata:
   name: push-to-external-registry-strategy
   namespace: rh-managed-mng-s-2-tenant
 spec:
-  bundle: quay.io/hacbs-release/pipeline-push-to-external-registry:main
   params:
   - name: extraConfigGitUrl
     value: https://github.com/hacbs-release/strategy-configs.git
@@ -20,6 +19,14 @@ spec:
     value: latest
   - name: addGitShaTag
     value: "true"
-  pipeline: push-to-external-registry
+  pipelineRef:
+    params:
+    - name: name
+      value: push-to-external-registry
+    - name: bundle
+      value: quay.io/hacbs-release/pipeline-push-to-external-registry:main
+    - name: kind
+      value: pipeline
+    resolver: bundles
   policy: rh-policy
   serviceAccount: release-service-account

--- a/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/release_strategy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/release_strategy.yaml
@@ -18,7 +18,14 @@ spec:
       value: latest
     - name: addGitShaTag
       value: "true"
-  pipeline: push-to-external-registry
-  bundle: quay.io/hacbs-release/pipeline-push-to-external-registry:main
+  pipelineRef:
+    resolver: bundles
+    params:
+    - name: name
+      value: push-to-external-registry
+    - name: bundle
+      value: quay.io/hacbs-release/pipeline-push-to-external-registry:main
+    - name: kind
+      value: pipeline
   policy: rh-policy
   serviceAccount: release-service-account


### PR DESCRIPTION
It should use the `pipelineRef` syntax, the previous syntax was deprecated.