### PR TITLE
Update EC policies

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-policy.yaml
@@ -15,7 +15,8 @@ spec:
   publicKey: k8s://openshift-pipelines/public-key
   sources:
   - data:
-    - github.com/enterprise-contract/ec-policies//data
+    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
     - github.com/enterprise-contract/ec-policies//policy/lib

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy.yaml
@@ -16,7 +16,8 @@ spec:
   publicKey: k8s://openshift-pipelines/public-key
   sources:
   - data:
-    - github.com/enterprise-contract/ec-policies//data
+    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
     - github.com/enterprise-contract/ec-policies//policy/lib

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -16,7 +16,8 @@ spec:
   publicKey: k8s://openshift-pipelines/public-key
   sources:
   - data:
-    - github.com/enterprise-contract/ec-policies//data
+    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
     - github.com/enterprise-contract/ec-policies//policy/lib

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -15,7 +15,8 @@ spec:
   publicKey: k8s://openshift-pipelines/public-key
   sources:
   - data:
-    - github.com/enterprise-contract/ec-policies//data
+    - github.com/release-engineering/rhtap-ec-policy//data
+    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
     - github.com/enterprise-contract/ec-policies//policy/lib

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -15,7 +15,7 @@ spec:
   publicKey: k8s://openshift-pipelines/public-key
   sources:
   - data:
-    - github.com/release-engineering/rhtap-ec-policy//data?ref=be7e1ef73bdeef2752dde400a52f9eab9b7542ca
+    - github.com/release-engineering/rhtap-ec-policy//data
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Release Policies
     policy:

--- a/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/ec-policy.yaml
@@ -14,7 +14,8 @@ spec:
   publicKey: 'k8s://openshift-pipelines/public-key'
   sources:
     - data:
-        - github.com/enterprise-contract/ec-policies//data
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
         - github.com/enterprise-contract/ec-policies//policy/lib
@@ -37,7 +38,8 @@ spec:
   publicKey: 'k8s://openshift-pipelines/public-key'
   sources:
     - data:
-        - github.com/enterprise-contract/ec-policies//data
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
         - github.com/enterprise-contract/ec-policies//policy/lib

--- a/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/ec-policy.yaml
@@ -15,7 +15,8 @@ spec:
   publicKey: 'k8s://openshift-pipelines/public-key'
   sources:
     - data:
-        - github.com/enterprise-contract/ec-policies//data
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
         - github.com/enterprise-contract/ec-policies//policy/lib

--- a/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/ec-policy.yaml
@@ -14,7 +14,8 @@ spec:
   publicKey: 'k8s://openshift-pipelines/public-key'
   sources:
     - data:
-        - github.com/enterprise-contract/ec-policies//data
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
         - github.com/enterprise-contract/ec-policies//policy/lib

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy.yaml
@@ -17,7 +17,7 @@ spec:
   sources:
     - name: Release Policies
       data:
-        - github.com/release-engineering/rhtap-ec-policy//data?ref=be7e1ef73bdeef2752dde400a52f9eab9b7542ca
+        - github.com/release-engineering/rhtap-ec-policy//data
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       policy:
         - oci::quay.io/enterprise-contract/ec-release-policy:git-1f33b3b@sha256:e9a2feafa17a2b189b20376e29d787a2f7816885491bd19ea37d4e95876ed380


### PR DESCRIPTION
This PR includes two commits:

> Use new location for EC data
>
> As part of https://issues.redhat.com/browse/EC-14, the Enterprise
> Contract policy data has a new home. This commit updates the ec-policies
> accordingly.


> Do not pin EC policy data sources
> 
> As learned in https://issues.redhat.com/browse/RHTAPBUGS-856, pinning
> policy data sources can lead to violations due to stale data. This
> commit ensures the lates policy data sources are used.
> 
> It is still recommended to pin the policy rule sources as these refer to
> rego code that needs to be properly gated before deploying. However,
> this process can be cumbersome. https://issues.redhat.com/browse/EC-193
> aims to address this for the EC policies in this repo.
