### PR TITLE
chore(RHTAPREL-645): use new release overlay

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-release-service-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-release-service-rpa.yaml
@@ -13,7 +13,7 @@ spec:
       addGitShaTag: true
       defaultTag: latest
     infra-deployment-update-script: |
-      sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/default?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/release/kustomization.yaml
+      sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/default?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/release/development/kustomization.yaml
       sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/grafana/?ref=\)\(.*\)|\1{{ revision }}|' -e 's//\1{{ revision }}/' components/monitoring/grafana/base/dashboards/release/kustomization.yaml
     mapping:
       components:

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-release-service.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-release-service.yaml
@@ -14,7 +14,7 @@ spec:
       addGitShaTag: true
       defaultTag: latest
     infra-deployment-update-script: |
-      sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/default?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/release/kustomization.yaml
+      sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/default?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/release/development/kustomization.yaml
       sed -i -e 's|\(https://github.com/redhat-appstudio/release-service/config/grafana/?ref=\)\(.*\)|\1{{ revision }}|' -e 's//\1{{ revision }}/' components/monitoring/grafana/base/dashboards/release/kustomization.yaml
     mapping:
       components:


### PR DESCRIPTION
- update of infra-deployments PR should within the development overlay

Depends on https://github.com/redhat-appstudio/infra-deployments/pull/2573