### PR TITLE
Add GitHub secret to Terraform RPA

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_terraform-provider-rhcs.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_terraform-provider-rhcs.yaml
@@ -7,9 +7,8 @@ spec:
   applications:
   - terraform-provider-rhcs
   data:
-    images:
-      addGitShaTag: true
-      defaultTag: latest
+    github:
+      githubSecret: github-secret
   origin: rhtap-migration-tenant
   pipelineRef:
     params:

--- a/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/release-plan-admission/rhtap-migration-rpa.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/release-plan-admission/rhtap-migration-rpa.yaml
@@ -48,9 +48,8 @@ spec:
   applications:
     - terraform-provider-rhcs
   data:
-    images:
-      addGitShaTag: true
-      defaultTag: latest
+    github:
+      githubSecret: github-secret
   origin: rhtap-migration-tenant
   pipelineRef:
     resolver: git


### PR DESCRIPTION
The Terraform release pipeline needs a GitHub secret to be able to
push the binaries and create a release. In this commit, we are adding
the name of the secret to data to be able to retrieve it from the
release pipeline