### PR TITLE
WiP: Grant all authenticated users rights to read ECP resources

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rbac.authorization.k8s.io_v1_rolebinding_public-ecp.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rbac.authorization.k8s.io_v1_rolebinding_public-ecp.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: public-ecp
+  namespace: rhtap-releng-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: enterprisecontractpolicy-viewer-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
   - persistent-volume-claim.yaml
+  - rb-public-ecp.yaml
   - rb-release-registry-dev.yaml
   - rb-release-registry-prod.yaml
   - rb-release-registry-staging.yaml

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-public-ecp.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-public-ecp.yaml
@@ -1,0 +1,15 @@
+# Allow any authenticated user to access to get/list/watch the EnterpriseContractPolicy resources
+# in the rhtap-releng-tenant namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: public-ecp
+  namespace: rhtap-releng-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: enterprisecontractpolicy-viewer-role
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated


### PR DESCRIPTION
In the rhtap-releng-tenant namespace.

See discussion in https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1698873456488529?thread_ts=1698711241.982099&cid=C04PZ7H0VA8 for context.