### PR TITLE
Change name of the release pipeline for Terraform

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_terraform-provider-rhcs-rhtap.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_terraform-provider-rhcs-rhtap.yaml
@@ -17,7 +17,7 @@ spec:
     - name: revision
       value: add-terraform-pipeline
     - name: pathInRepo
-      value: pipelines/terraform-release/terraform-release.yaml
+      value: pipelines/release-to-github-signed/release-to-github-signed.yaml
     resolver: git
   policy: rh-policy
   serviceAccount: release-service-account

--- a/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/release-plan-admission/rhtap-migration-rpa.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/release-plan-admission/rhtap-migration-rpa.yaml
@@ -59,6 +59,6 @@ spec:
       - name: revision
         value: add-terraform-pipeline
       - name: pathInRepo
-        value: "pipelines/terraform-release/terraform-release.yaml"
+        value: "pipelines/release-to-github-signed/release-to-github-signed.yaml"
   policy: rh-policy
   serviceAccount: release-service-account


### PR DESCRIPTION
Change name of the release pipeline for Terraform from terraform-release to release-to-github-signed to make it more general