### PR TITLE
Remove standing attribution from internal-services

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1alpha1_releaseplan_internal-services-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1alpha1_releaseplan_internal-services-release-to-quay-rhtap-ser.yaml
@@ -3,7 +3,6 @@ kind: ReleasePlan
 metadata:
   labels:
     release.appstudio.openshift.io/auto-release: "true"
-    release.appstudio.openshift.io/standing-attribution: "true"
   name: internal-services-release-to-quay-rhtap-ser
   namespace: rhtap-release-2-tenant
 spec:

--- a/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/release_plan.yaml
@@ -17,7 +17,6 @@ metadata:
   namespace: rhtap-release-2-tenant
   labels:
     release.appstudio.openshift.io/auto-release: 'true'
-    release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: internal-services
   target: rh-managed-rhtap-ser-tenant


### PR DESCRIPTION
- attempting to see if we can update this label after argo has synced it.