### PR TITLE
chore: revert to using main for release pipeline

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-rpa.yaml
@@ -29,9 +29,9 @@ spec:
   pipelineRef:
     params:
     - name: url
-      value: https://github.com/scoheb/release-service-catalog.git
+      value: https://github.com/redhat-appstudio/release-service-catalog.git
     - name: revision
-      value: refactor-slack
+      value: main
     - name: pathInRepo
       value: pipelines/rhtap-service-push/rhtap-service-push.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-image-controller-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-image-controller-rpa.yaml
@@ -28,9 +28,9 @@ spec:
   pipelineRef:
     params:
     - name: url
-      value: https://github.com/scoheb/release-service-catalog.git
+      value: https://github.com/redhat-appstudio/release-service-catalog.git
     - name: revision
-      value: refactor-slack
+      value: main
     - name: pathInRepo
       value: pipelines/rhtap-service-push/rhtap-service-push.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-internal-services-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-internal-services-rpa.yaml
@@ -26,9 +26,9 @@ spec:
   pipelineRef:
     params:
     - name: url
-      value: https://github.com/scoheb/release-service-catalog.git
+      value: https://github.com/redhat-appstudio/release-service-catalog.git
     - name: revision
-      value: refactor-slack
+      value: main
     - name: pathInRepo
       value: pipelines/rhtap-service-push/rhtap-service-push.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-release-service-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-release-service-rpa.yaml
@@ -31,9 +31,9 @@ spec:
   pipelineRef:
     params:
     - name: url
-      value: https://github.com/scoheb/release-service-catalog.git
+      value: https://github.com/redhat-appstudio/release-service-catalog.git
     - name: revision
-      value: refactor-slack
+      value: main
     - name: pathInRepo
       value: pipelines/rhtap-service-push/rhtap-service-push.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-remotesecret-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-remotesecret-rpa.yaml
@@ -32,9 +32,9 @@ spec:
   pipelineRef:
     params:
     - name: url
-      value: https://github.com/scoheb/release-service-catalog.git
+      value: https://github.com/redhat-appstudio/release-service-catalog.git
     - name: revision
-      value: refactor-slack
+      value: main
     - name: pathInRepo
       value: pipelines/rhtap-service-push/rhtap-service-push.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-build.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-build.yaml
@@ -32,9 +32,9 @@ spec:
     resolver: git
     params:
       - name: url
-        value: "https://github.com/scoheb/release-service-catalog.git"
+        value: "https://github.com/redhat-appstudio/release-service-catalog.git"
       - name: revision
-        value: refactor-slack
+        value: main
       - name: pathInRepo
         value: "pipelines/rhtap-service-push/rhtap-service-push.yaml"
   policy: rh-policy

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-image-controller.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-image-controller.yaml
@@ -29,9 +29,9 @@ spec:
     resolver: git
     params:
       - name: url
-        value: "https://github.com/scoheb/release-service-catalog.git"
+        value: "https://github.com/redhat-appstudio/release-service-catalog.git"
       - name: revision
-        value: refactor-slack
+        value: main
       - name: pathInRepo
         value: "pipelines/rhtap-service-push/rhtap-service-push.yaml"
   policy: rh-policy

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-internal-services.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-internal-services.yaml
@@ -28,9 +28,9 @@ spec:
     resolver: git
     params:
       - name: url
-        value: "https://github.com/scoheb/release-service-catalog.git"
+        value: "https://github.com/redhat-appstudio/release-service-catalog.git"
       - name: revision
-        value: refactor-slack
+        value: main
       - name: pathInRepo
         value: "pipelines/rhtap-service-push/rhtap-service-push.yaml"
   policy: rh-policy

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-release-service.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-release-service.yaml
@@ -33,9 +33,9 @@ spec:
     resolver: git
     params:
       - name: url
-        value: "https://github.com/scoheb/release-service-catalog.git"
+        value: "https://github.com/redhat-appstudio/release-service-catalog.git"
       - name: revision
-        value: refactor-slack
+        value: main
       - name: pathInRepo
         value: "pipelines/rhtap-service-push/rhtap-service-push.yaml"
   policy: rh-policy

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-remotesecret.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-remotesecret.yaml
@@ -35,9 +35,9 @@ spec:
     resolver: git
     params:
       - name: url
-        value: "https://github.com/scoheb/release-service-catalog.git"
+        value: "https://github.com/redhat-appstudio/release-service-catalog.git"
       - name: revision
-        value: refactor-slack
+        value: main
       - name: pathInRepo
         value: "pipelines/rhtap-service-push/rhtap-service-push.yaml"
   policy: rh-policy


### PR DESCRIPTION
- now that https://github.com/redhat-appstudio/release-service-catalog/pull/295 is merged, we can use redhat-appstudio/release-service-catalog