### PR TITLE
Permit all users to read ECP resources in the central release namespace

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rbac.authorization.k8s.io_v1_rolebinding_tenant-ecp.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rbac.authorization.k8s.io_v1_rolebinding_tenant-ecp.yaml
@@ -8,6 +8,6 @@ roleRef:
   kind: ClusterRole
   name: enterprisecontractpolicy-viewer-role
 subjects:
-- kind: ServiceAccount
-  name: appstudio-pipeline
-  namespace: rhtas-tenant
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-ecp.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-ecp.yaml
@@ -8,6 +8,6 @@ roleRef:
   kind: ClusterRole
   name: enterprisecontractpolicy-viewer-role
 subjects:
-  - kind: ServiceAccount
-    name: appstudio-pipeline
-    namespace: rhtas-tenant
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated


### PR DESCRIPTION
This will be useful for IntegrationTestScenarios.