### PR TITLE
Modify EC policy config for centos-bootc to get EC checks passing

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -9,6 +9,7 @@ spec:
     - hermetic_build_task
     - step_image_registries
     - tasks.required_tasks_found:prefetch-dependencies
+    - sbom_cyclonedx
     include:
     - '@minimal'
     - '@slsa3'
@@ -25,3 +26,9 @@ spec:
     name: Release Policies
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-fab6481@sha256:757440524b5312a14170ee688e21e973fb1b9510a6a0ed862aabd4957d392f4d
+    ruleData:
+      allowed_registry_prefixes:
+      - registry.access.redhat.com/
+      - registry.redhat.io/
+      - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
+      - localhost/rhtap-final-image

--- a/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
@@ -31,3 +31,11 @@ spec:
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       policy:
         - oci::quay.io/enterprise-contract/ec-release-policy:git-fab6481@sha256:757440524b5312a14170ee688e21e973fb1b9510a6a0ed862aabd4957d392f4d
+      ruleData:
+        allowed_registry_prefixes:
+          # These are the defaults
+          - registry.access.redhat.com/
+          - registry.redhat.io/
+          - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
+          # Custom addition to permit localhost/rhtap-final-image as a base image
+          - localhost/rhtap-final-image

--- a/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
@@ -10,6 +10,8 @@ spec:
         # positives due to https://issues.redhat.com/browse/OCPBUGS-8428
       - step_image_registries
       - tasks.required_tasks_found:prefetch-dependencies # prefetch is not required
+      # Currently using a non-standard buildah task that does not push an SBOM
+      - sbom_cyclonedx
     include:
         - '@minimal'
         - '@slsa3'


### PR DESCRIPTION
See [slack thread here](https://redhat-internal.slack.com/archives/C04RP7SE1ST/p1700663097552329) for details.

There are two changes:

* Waive the requirement for a CycloneDX format SBOM to be created
* Permit the use of `localhost/rhtap-final-image` as a base image

Note that the CVE check, currently failing, is left as-is.