### PR TITLE
Warn only for centos-bootc high severity CVEs

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -32,3 +32,7 @@ spec:
       - registry.redhat.io/
       - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
       - localhost/rhtap-final-image
+      restrict_cve_security_levels:
+      - critical
+      warn_cve_security_levels:
+      - high

--- a/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
@@ -39,3 +39,10 @@ spec:
           - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
           # Custom addition to permit localhost/rhtap-final-image as a base image
           - localhost/rhtap-final-image
+        # Currently there are four high severity CVEs that aren't practical to fix
+        # in the short term. Configure 'high' severity CVEs to be warnings instead of
+        # violations. The default values are:
+        #  restrict_cve_security_levels: [critical, high]
+        #  warn_cve_security_levels: []
+        restrict_cve_security_levels: [critical]
+        warn_cve_security_levels: [high]


### PR DESCRIPTION
A followup from #133. The CVEs being detected require upstream fixes and aren't likely to be fixed in the short term.

Rather than skipping the CVE check entirely, we can provide customized rule data so the check will not produce a violation unless critical severity CVEs are found.

This patch can be removed in future when/if the high severity CVEs are fixed.