### PR TITLE
removing lib directory and replacing with oci bundle

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-policy.yaml
@@ -19,5 +19,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
-    - github.com/enterprise-contract/ec-policies//policy/lib
-    - github.com/enterprise-contract/ec-policies//policy/release
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy.yaml
@@ -20,5 +20,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
-    - github.com/enterprise-contract/ec-policies//policy/lib
-    - github.com/enterprise-contract/ec-policies//policy/release
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -20,5 +20,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
-    - github.com/enterprise-contract/ec-policies//policy/lib
-    - github.com/enterprise-contract/ec-policies//policy/release
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -19,5 +19,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
-    - github.com/enterprise-contract/ec-policies//policy/lib
-    - github.com/enterprise-contract/ec-policies//policy/release
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e

--- a/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/ec-policy.yaml
@@ -18,8 +18,7 @@ spec:
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
-        - github.com/enterprise-contract/ec-policies//policy/lib
-        - github.com/enterprise-contract/ec-policies//policy/release
+      - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: EnterpriseContractPolicy
@@ -42,5 +41,4 @@ spec:
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
-        - github.com/enterprise-contract/ec-policies//policy/lib
-        - github.com/enterprise-contract/ec-policies//policy/release
+      - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e

--- a/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/ec-policy.yaml
@@ -19,8 +19,7 @@ spec:
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
-        - github.com/enterprise-contract/ec-policies//policy/lib
-        - github.com/enterprise-contract/ec-policies//policy/release
+      - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: EnterpriseContractPolicy

--- a/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/ec-policy.yaml
@@ -18,5 +18,4 @@ spec:
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
-        - github.com/enterprise-contract/ec-policies//policy/lib
-        - github.com/enterprise-contract/ec-policies//policy/release
+      - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e


### PR DESCRIPTION
This PR is in favor of https://github.com/redhat-appstudio/tenants-config/pull/135, which should be closed. Merging this will get the ec-policy.yaml files using the OCI bundle and using the latest.