### PR TITLE
feat(STONEINTG-696): add integration-service application

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-integration-service-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-integration-service-rpa.yaml
@@ -1,0 +1,38 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+  name: rhtap-integration-service-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  applications:
+  - integration-service
+  data:
+    images:
+      addGitShaTag: true
+      defaultTag: latest
+    infra-deployment-update-script: |
+      sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/integration/development/kustomization.yaml
+      sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/integration/staging/kustomization.yaml
+      # Temporary disabled grafana updates
+      # sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
+    mapping:
+      components:
+      - name: integration-service
+        repository: quay.io/redhat-appstudio/integration-service
+    pyxis:
+      secret: pyxis-production-secret
+      server: production
+  origin: rhtap-integration-tenant
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: revision
+      value: production
+    - name: pathInRepo
+      value: pipelines/rhtap-service-push/rhtap-service-push.yaml
+    resolver: git
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1alpha1_releaseplan_integration-service-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1alpha1_releaseplan_integration-service-release-to-quay-rhtap-ser.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: integration-service-release-to-quay-rhtap-ser
+  namespace: rhtap-integration-tenant
+spec:
+  application: integration-service
+  displayName: integration-service-release-to-quay
+  target: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_integration-service-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_integration-service-enterprise-contract.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: integration-service-enterprise-contract
+  namespace: rhtap-integration-tenant
+spec:
+  application: integration-service
+  contexts:
+  - description: Application testing
+    name: application
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - ec-policy.yaml
 - persistent-volume-claim.yaml
 - release-pipeline-sa.yaml
+- release_plan_admission-integration-service.yaml
 - remote-secrets
 
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-integration-service.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-integration-service.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: rhtap-integration-service-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+spec:
+  applications:
+    - integration-service
+  data:
+    images:
+      addGitShaTag: true
+      defaultTag: latest
+    infra-deployment-update-script: |
+      sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/integration/development/kustomization.yaml
+      sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/integration/staging/kustomization.yaml
+      # Temporary disabled grafana updates
+      # sed -i -e 's|\(https://github.com/redhat-appstudio/integration-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
+    mapping:
+      components:
+        - name: integration-service
+          repository: "quay.io/redhat-appstudio/integration-service"
+    pyxis:
+      secret: pyxis-production-secret
+      server: production
+  origin: rhtap-integration-tenant
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+      - name: revision
+        value: production
+      - name: pathInRepo
+        value: "pipelines/rhtap-service-push/rhtap-service-push.yaml"
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa

--- a/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/integration_test_scenario.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: integration-service-enterprise-contract
+  namespace: rhtap-integration-tenant
+spec:
+  application: integration-service
+  contexts:
+    - description: Application testing
+      name: application
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/build-definitions'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- integration_test_scenario.yaml
+- release_plan.yaml

--- a/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/release_plan.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: integration-service-release-to-quay-rhtap-ser
+  namespace: rhtap-integration-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  application: integration-service
+  displayName: integration-service-release-to-quay
+  target: rh-managed-rhtap-ser-tenant


### PR DESCRIPTION
Add integration-service application https://github.com/redhat-appstudio/integration-service
1. add IntegrationTestScneario for integration-service
2. add releasePlan for integration-service for integration-service
3. add releasePlanAdmission for integration-service


Signed-off-by: Hongwei Liu <hongliu@redhat.com>