### PR TITLE
Add release configuration for build-trusted-artacts

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_build-trusted-artifacts-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_build-trusted-artifacts-to-quay-rhtap-ser.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: build-trusted-artifacts-to-quay-rhtap-ser
+  namespace: rhtap-build-tenant
+spec:
+  application: build-trusted-artifacts
+  target: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-trusted-artifacts-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-trusted-artifacts-enterprise-contract.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: build-trusted-artifacts-enterprise-contract
+  namespace: rhtap-build-tenant
+spec:
+  application: build-trusted-artifacts
+  contexts:
+  - description: Application testing
+    name: application
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-build-trusted-artifacts.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-build-trusted-artifacts.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: rhtap-build-trusted-artifacts-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  applications:
+    - build-trusted-artifacts
+  data:
+    images:
+      addGitShaTag: true
+      defaultTag: latest
+    mapping:
+      components:
+        - name: build-trusted-artifacts
+          repository: "quay.io/redhat-appstudio/build-trusted-artifacts"
+    pyxis:
+      secret: pyxis-production-secret
+      server: production
+    slack:
+      slack-notification-secret: "build-team-slack-webhook-notification-secret"
+      slack-webhook-notification-secret-keyname: "build"
+  origin: rhtap-build-tenant
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+      - name: revision
+        value: production
+      - name: pathInRepo
+        value: "pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml"
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
@@ -37,3 +37,23 @@ spec:
       - name: pathInRepo
         value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
     resolver: git
+---
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: build-trusted-artifacts-enterprise-contract
+  namespace: rhtap-build-tenant
+spec:
+  application: build-trusted-artifacts
+  contexts:
+    - description: Application testing
+      name: application
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/build-definitions'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
@@ -21,3 +21,15 @@ metadata:
 spec:
   application: image-controller
   target: rh-managed-rhtap-ser-tenant
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: build-trusted-artifacts-to-quay-rhtap-ser
+  namespace: rhtap-build-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  application: build-trusted-artifacts
+  target: rh-managed-rhtap-ser-tenant


### PR DESCRIPTION
I'm hoping this will allow the image built from the `build-trusted-artifacts` Application from the `rhtap-build-tenant` to be pushed to quay.io/redhat-appstudio repository.

Ref: https://issues.redhat.com/browse/EC-303