### PR TITLE
Include ReleasePlanAdmission for trusted-artifacts

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-trusted-artifacts-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-trusted-artifacts-rpa.yaml
@@ -1,0 +1,37 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: rhtap-build-trusted-artifacts-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  applications:
+  - build-trusted-artifacts
+  data:
+    images:
+      addGitShaTag: true
+      defaultTag: latest
+    mapping:
+      components:
+      - name: build-trusted-artifacts
+        repository: quay.io/redhat-appstudio/build-trusted-artifacts
+    pyxis:
+      secret: pyxis-production-secret
+      server: production
+    slack:
+      slack-notification-secret: build-team-slack-webhook-notification-secret
+      slack-webhook-notification-secret-keyname: build
+  origin: rhtap-build-tenant
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: revision
+      value: production
+    - name: pathInRepo
+      value: pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+    resolver: git
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - release_plan_admission-segment-bridge.yaml
 - release_plan_admission-remotesecret.yaml
 - release_plan_admission-spi.yaml
+- release_plan_admission-build-trusted-artifacts.yaml
 - release-service-account-rb.yaml
 - ec-policy.yaml
 - persistent-volume-claim.yaml


### PR DESCRIPTION
This was missing in the initial pull request and results with:

```
 no ReleasePlanAdmission found in the target (rh-managed-rhtap-ser-tenant) for application 'build-trusted-artifacts'
```