### PR TITLE
chore: update o11y integartion scenario

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_o11y-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_o11y-enterprise-contract.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: rhtap-o11y-tenant
 spec:
   application: o11y
+  configuration:
+    exclude:
+    - attestation_task_bundle.task_ref_bundles_acceptable
   contexts:
   - description: Application testing
     name: application

--- a/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
@@ -28,6 +28,13 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  configuration:
+    exclude:
+      # Because o11y includes a custom task in it's build pipelines in order to run unit
+      # tests. That should be fine, but EC complains about it today. Grant this exception until EC
+      # can learn to tolerate it.
+      # https://issues.redhat.com/browse/RHTAP-1707
+      - 'attestation_task_bundle.task_ref_bundles_acceptable'
   resolverRef:
     params:
       - name: url


### PR DESCRIPTION
update o11y integartion scenario to grant an
exception until the custom tasks can be run