### PR TITLE
chore: update o11y integration scenario

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_o11y-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_o11y-enterprise-contract.yaml
@@ -8,6 +8,7 @@ spec:
   configuration:
     exclude:
     - attestation_task_bundle.task_ref_bundles_acceptable
+    - attestation_task_bundle.tasks_defined_in_bundle
   contexts:
   - description: Application testing
     name: application

--- a/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
@@ -35,6 +35,7 @@ spec:
       # can learn to tolerate it.
       # https://issues.redhat.com/browse/RHTAP-1707
       - 'attestation_task_bundle.task_ref_bundles_acceptable'
+      - 'attestation_task_bundle.tasks_defined_in_bundle'
   resolverRef:
     params:
       - name: url


### PR DESCRIPTION
update o11y integartion scenario to grant an
exception until the custom tasks can be run