### PR TITLE
Configure EC check for the rh-syft application

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-syft-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-syft-enterprise-contract.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: rh-syft-enterprise-contract
+  namespace: rhtap-build-tenant
+spec:
+  application: rh-syft
+  contexts:
+  - description: Application testing
+    name: application
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract-redhat.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
@@ -57,3 +57,23 @@ spec:
       - name: pathInRepo
         value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
     resolver: git
+---
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: rh-syft-enterprise-contract
+  namespace: rhtap-build-tenant
+spec:
+  application: rh-syft
+  contexts:
+    - description: Application testing
+      name: application
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/build-definitions'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/enterprise-contract-redhat.yaml
+    resolver: git


### PR DESCRIPTION
STONEBLD-2004

Use the 'redhat' Enterprise Contract policy (assuming it is the same policy as redhat-no-hermetic but also requires hermetic builds).

Background:

RH-syft is the Syft productization app, lives in the rhtap-build workspace and builds https://github.com/redhat-appstudio/rh-syft.

Its location will likely change when we figure out where Syft really belongs. For now, it will live here so that we can start trying out the productization process.