### PR TITLE
Add release for EC v0.1 alpha

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-contract-tenant/appstudio.redhat.com_v1alpha1_releaseplan_ec-v01-alpha-registry-redhat-io.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-contract-tenant/appstudio.redhat.com_v1alpha1_releaseplan_ec-v01-alpha-registry-redhat-io.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: ec-v01-alpha-registry-redhat-io
+  namespace: rhtap-contract-tenant
+spec:
+  application: ec-v01-alpha
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-contract-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-contract-tenant/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+resources:
+- release_plan.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/cluster/stone-prd-rh01/tenants/rhtap-contract-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-contract-tenant/release_plan.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  namespace: rhtap-contract-tenant
+  name: ec-v01-alpha-registry-redhat-io
+spec:
+  application: ec-v01-alpha
+  target: rhtap-releng-tenant


### PR DESCRIPTION
Note that I'm using the rhtas-tenant as an example rather than the example from the documentation. Notably the target is rhtap-releng-tenant and not rh-managed-rhtap-ser-tenant. (Let me know if I'm copying an incorrect example.)