### PR TITLE
Add ReleasePlan for the rh-syft application

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_rh-syft-registry-redhat-io.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_rh-syft-registry-redhat-io.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "false"
+  name: rh-syft-registry-redhat-io
+  namespace: rhtap-build-tenant
+spec:
+  application: rh-syft
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
@@ -33,3 +33,14 @@ metadata:
 spec:
   application: build-trusted-artifacts
   target: rh-managed-rhtap-ser-tenant
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: rh-syft-registry-redhat-io
+  namespace: rhtap-build-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'false'
+spec:
+  application: rh-syft
+  target: rhtap-releng-tenant


### PR DESCRIPTION
RH-syft will be released to registry.redhat.io via a ReleasePlanAdmission in the rhtap-releng tenant.