### PR TITLE
chore: Add ReleasePlanAdmission for HAS

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-application-service-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-application-service-rpa.yaml
@@ -28,7 +28,7 @@ spec:
       - name: application-service
         repository: quay.io/redhat-appstudio/application-service
     pyxis:
-      secret: pyxis-staging-secret
+      secret: pyxis-production-secret
       server: production
   origin: rhtap-has-tenant
   pipelineRef:

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-application-service-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-application-service-rpa.yaml
@@ -1,0 +1,44 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+  name: rhtap-application-service-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  applications:
+  - application-service
+  data:
+    images:
+      addGitShaTag: true
+      defaultTag: latest
+    infra-deployment-update-script: "sed -i -e 's|\\(https://github.com/redhat-appstudio/application-service/.*?ref=\\)\\(.*\\)|\\1{{
+      revision }}|' -e 's/\\(newTag: \\).*/\\1{{ revision }}/' components/has/base/kustomization.yaml\nsed
+      -i -e 's|\\(https://github.com/redhat-appstudio/application-service/.*?ref=\\)\\(.*\\)|\\1{{
+      revision }}|' -e 's/\\(newTag: \\).*/\\1{{ revision }}/' components/has/production/kustomization.yaml\nsed
+      -i -e 's|\\(https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=\\)\\(.*\\)|\\1{{
+      revision }}|' -e 's/\\(newTag: \\).*/\\1{{ revision }}/' components/has/production/kustomization.yaml\nsed
+      -i -e 's|\\(https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=\\)\\(.*\\)|\\1{{
+      revision }}|' -e 's/\\(newTag: \\).*/\\1{{ revision }}/' components/has/staging/kustomization.yaml\nsed
+      -i -e 's|\\(https://github.com/redhat-appstudio/application-service/config/monitoring/?ref=\\)\\(.*\\)|\\1{{
+      revision }}|' -e 's/\\(newTag: \\).*/\\1{{ revision }}/' components/monitoring/grafana/base/dashboards/has/kustomization.yaml
+      \   \n"
+    mapping:
+      components:
+      - name: application-service
+        repository: quay.io/redhat-appstudio/application-service
+    pyxis:
+      secret: pyxis-staging-secret
+      server: production
+  origin: rhtap-has-tenant
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/release-service-catalog.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/rhtap-service-push/rhtap-service-push.yaml
+    resolver: git
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- release_plan_admission-application-service.yaml
 - release_plan_admission-build.yaml
 - release_plan_admission-external-secrets.yaml
 - release_plan_admission-image-controller.yaml

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-application-service.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-application-service.yaml
@@ -23,7 +23,7 @@ spec:
         - name: application-service
           repository: "quay.io/redhat-appstudio/application-service"
     pyxis:
-      secret: pyxis-staging-secret
+      secret: pyxis-production-secret
       server: production
   origin: rhtap-has-tenant
   pipelineRef:

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-application-service.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-application-service.yaml
@@ -1,0 +1,39 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: rhtap-application-service-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+spec:
+  applications:
+    - application-service
+  data:
+    images:
+      addGitShaTag: true
+      defaultTag: latest
+    infra-deployment-update-script: |
+      sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/base/kustomization.yaml
+      sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/.*?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/production/kustomization.yaml
+      sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/production/kustomization.yaml
+      sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/has/staging/kustomization.yaml
+      sed -i -e 's|\(https://github.com/redhat-appstudio/application-service/config/monitoring/?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/monitoring/grafana/base/dashboards/has/kustomization.yaml    
+    mapping:
+      components:
+        - name: application-service
+          repository: "quay.io/redhat-appstudio/application-service"
+    pyxis:
+      secret: pyxis-staging-secret
+      server: production
+  origin: rhtap-has-tenant
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: "pipelines/rhtap-service-push/rhtap-service-push.yaml"
+  policy: rh-policy
+  serviceAccount: rhtap-servicerelease-sa


### PR DESCRIPTION
This PR adds a ReleasePlanAdmission for HAS, as outlined in the onboarding doc.

The infra-deployments update script I used is the same script that was previously used in HAS:

https://github.com/redhat-appstudio/application-service/blob/948fa4e32d2d2545af439a04750a8a690fe68a19/.tekton/push.yaml#L19-L23