### PR TITLE
Change Test to optional

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-tekton-insights.yaml
@@ -2,7 +2,7 @@ apiVersion: appstudio.redhat.com/v1beta1
 kind: IntegrationTestScenario
 metadata:
   labels:
-    test.appstudio.openshift.io/optional: "false"
+    test.appstudio.openshift.io/optional: "true"
   name: insights-ingress-go-tekton-insights
   namespace: rhtap-hcc-pipeline-tenant
 spec:

--- a/cluster/stone-prd-rh01/tenants/rhtap-hcc-pipeline-tenant/integration_test_tekton.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-hcc-pipeline-tenant/integration_test_tekton.yaml
@@ -2,7 +2,7 @@ apiVersion: appstudio.redhat.com/v1beta1
 kind: IntegrationTestScenario
 metadata:
   labels:
-    test.appstudio.openshift.io/optional: "false" # Change to "true" if you don't need the test to be mandatory
+    test.appstudio.openshift.io/optional: "true" # Change to "true" if you don't need the test to be mandatory
   name: insights-ingress-go-tekton-insights
   namespace: rhtap-hcc-pipeline-tenant
 spec:


### PR DESCRIPTION
Changing tekton test to optional so that the team can still release without it.
Tekton test is currently being fixed to have the right token but until then this will be optional