### PR TITLE
Add registry pull secret for rh-syft builds

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets.io_v1beta1_externalsecret_registry-redhat-io-pull-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets.io_v1beta1_externalsecret_registry-redhat-io-pull-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: registry-redhat-io-pull-secret
+  namespace: rhtap-build-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: production/build/rh-syft/registry-pull-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: registry-redhat-io-pull-secret
+    template:
+      data:
+        .dockerconfigjson: '{{ .config }}'
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/v1_serviceaccount_appstudio-pipeline.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/v1_serviceaccount_appstudio-pipeline.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+imagePullSecrets:
+- name: registry-redhat-io-pull-secret
+kind: ServiceAccount
+metadata:
+  name: appstudio-pipeline
+  namespace: rhtap-build-tenant
+secrets:
+- name: registry-redhat-io-pull-secret

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - infra-deployments-pr-creator.yaml
+- registry-redhat-io-pull-secret.yaml
 namespace: rhtap-build-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/registry-redhat-io-pull-secret.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/registry-redhat-io-pull-secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: registry-redhat-io-pull-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/rh-syft/registry-pull-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: registry-redhat-io-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - release_plan.yaml
 - external-secrets
 - integration_test_scenario.yaml
+- service_account.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/service_account.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/service_account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appstudio-pipeline
+  namespace: rhtap-build-tenant
+secrets:
+  - name: registry-redhat-io-pull-secret
+imagePullSecrets:
+  - name: registry-redhat-io-pull-secret


### PR DESCRIPTION
The rh-syft build will need to pull base images from
brew.registry.redhat.io. Add an ExternalSecret to make the service
account token available in the rhtap-build-tenant namespace.

Link the resulting Secret to the appstudio-pipeline SA.