### PR TITLE
feat(RHTAPREL-722) add red hat acm service aaccount and secret to releng

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_quay-token-redhat-acm-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_quay-token-redhat-acm-remote-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: quay-token-redhat-acm-remote-secret
+  namespace: rhtap-releng-tenant
+spec:
+  secret:
+    linkedTo:
+    - serviceAccount:
+        reference:
+          name: redhat-acm-service-account
+    name: quay-token-secret
+    type: kubernetes.io/dockerconfigjson
+  targets:
+  - namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-redhat-acm-service-account.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-redhat-acm-service-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: redhat-acm-service-account
+  namespace: rhtap-releng-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: redhat-acm-service-account
+    namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - remote_secret-quay-token-hacbs-release-tests.yaml
   - remote_secret-quay-token-redhat-services-prod.yaml
   - remote_secret-quay-token-redhat-services-staging.yaml
+  - remote_secret-quay-token-redhat-acm.yaml
   - remote_secret-quay-token-redhat-prod.yaml
   - remote_secret-quay-token-redhat-staging.yaml
   - remote_secret-quay-token-redhat-dev.yaml

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-quay-token-redhat-acm.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-quay-token-redhat-acm.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: quay-token-redhat-acm-remote-secret
+spec:
+  secret:
+    name: quay-token-secret
+    type: kubernetes.io/dockerconfigjson
+    linkedTo:
+      - serviceAccount:
+          reference:
+            name: redhat-acm-service-account
+  targets:
+    - namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/sa-redhat-acm-service-account.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/sa-redhat-acm-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redhat-acm-service-account
+  namespace: rhtap-releng-tenant


### PR DESCRIPTION
- To migrate red-hat-acm from tenants to releng, we need SA and Secrets.