### PR TITLE
Adding a ServiceAccount and RemoteSecret for the Maestro project

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_quay-token-maestro-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_quay-token-maestro-remote-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: quay-token-maestro-remote-secret
+  namespace: rhtap-releng-tenant
+spec:
+  secret:
+    linkedTo:
+    - serviceAccount:
+        reference:
+          name: maestro-service-account
+    name: quay-token-secret
+    type: kubernetes.io/dockerconfigjson
+  targets:
+  - namespace: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rbac.authorization.k8s.io_v1_rolebinding_maestro-service-account.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rbac.authorization.k8s.io_v1_rolebinding_maestro-service-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: maestro-service-account
+  namespace: rhtap-releng-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: maestro-service-account
+  namespace: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/v1_serviceaccount_maestro-service-account.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/v1_serviceaccount_maestro-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: maestro-service-account
+  namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/kustomization.yaml
@@ -1,9 +1,11 @@
 resources:
   - persistent-volume-claim.yaml
   - rb-ecp.yaml
+  - rb-maestro-service-account.yaml
   - rb-release-pipelines.yaml
   - rb-releng-gitops-repo-ro.yaml
   - rb-releng-gitops-repo-rw.yaml
+  - sa-maestro-service-account.yaml
   - sa-release-app-interface-prod.yaml
   - sa-release-app-interface-staging.yaml
   - sa-release-index-image-prod.yaml

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-maestro-service-account.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-maestro-service-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: maestro-service-account
+  namespace: rhtap-releng-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+  - kind: ServiceAccount
+    name: maestro-service-account
+    namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - remote_secret-pyxis-prod-secret.yaml
   - remote_secret-pyxis-staging-secret.yaml
   - remote_secret-quay-token-hacbs-release-tests.yaml
+  - remote_secret-quay-token-maestro.yaml
   - remote_secret-quay-token-redhat-services-prod.yaml
   - remote_secret-quay-token-redhat-services-staging.yaml
   - remote_secret-quay-token-redhat-prod.yaml

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-quay-token-maestro.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-quay-token-maestro.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: appstudio.redhat.com/v1beta1
+kind: RemoteSecret
+metadata:
+  name: quay-token-maestro-remote-secret
+spec:
+  secret:
+    name: quay-token-secret
+    type: kubernetes.io/dockerconfigjson
+    linkedTo:
+      - serviceAccount:
+          reference:
+            name: maestro-service-account
+  targets:
+    - namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/sa-maestro-service-account.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/sa-maestro-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: maestro-service-account
+  namespace: rhtap-releng-tenant


### PR DESCRIPTION
## Summary of Changes

This PR adds a RemoteSecret (the OG secret still needs to be created, pending app-sre access / providing the secret) and related RoleBinding and ServiceAccount for the onboarding of the `maestro` application in the `maestro-rhtap` workspace with a ReleasePlan!   