### PR TITLE
feat: change policy

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_internal-services-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_internal-services-enterprise-contract.yaml
@@ -10,7 +10,7 @@ spec:
     name: application
   params:
   - name: POLICY_CONFIGURATION
-    value: rhtap-releng-tenant/registry-standard
+    value: rhtap-releng-tenant/konflux-components
   resolverRef:
     params:
     - name: url

--- a/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/integration_test_scenario.yaml
@@ -33,7 +33,7 @@ spec:
       name: application
   params:
     - name: POLICY_CONFIGURATION
-      value: rhtap-releng-tenant/registry-standard
+      value: rhtap-releng-tenant/konflux-components
   resolverRef:
     params:
       - name: url


### PR DESCRIPTION
IntegrationTestScenario for rhtap-release-2-tenant uses now a policy which exclude hermetic_build_task.