### PR TITLE
chore(RHTAPWATCH-840): Update EC exclusions for o11y

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy-o11y.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy-o11y.yaml
@@ -11,8 +11,6 @@ spec:
     - tasks.required_tasks_found:prefetch-dependencies
     - attestation_task_bundle.task_ref_bundles_acceptable
     - attestation_task_bundle.tasks_defined_in_bundle
-    - labels.disallowed_inherited_labels
-    - tasks.required_tasks_found
     include:
     - '@redhat'
   description: A special reduced ruleset for Observability.

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy-o11y.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy-o11y.yaml
@@ -16,8 +16,6 @@ spec:
         # https://issues.redhat.com/browse/RHTAP-1707
       - 'attestation_task_bundle.task_ref_bundles_acceptable'
       - 'attestation_task_bundle.tasks_defined_in_bundle'
-      - 'labels.disallowed_inherited_labels'
-      - 'tasks.required_tasks_found'
     include:
       - '@redhat'
   description: 'A special reduced ruleset for Observability.'


### PR DESCRIPTION
Removed exclusions disallowed_inherited_labels and required_tasks_found since we modified related o11y code.