### PR TITLE
Update Enterprise Contract release policy

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -25,7 +25,7 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Release Policies
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-fab6481@sha256:757440524b5312a14170ee688e21e973fb1b9510a6a0ed862aabd4957d392f4d
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6
     ruleData:
       allowed_registry_prefixes:
       - registry.access.redhat.com/

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-policy.yaml
@@ -19,4 +19,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy.yaml
@@ -20,4 +20,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -20,4 +20,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -17,4 +17,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy-o11y.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy-o11y.yaml
@@ -21,4 +21,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Release Policies
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-bb96264@sha256:1bc02bc28a9eb029a152016a507800397acd7853f1f8866592ca0eb59593cec1
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -19,4 +19,4 @@ spec:
     - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
     name: Release Policies
     policy:
-    - oci::quay.io/enterprise-contract/ec-release-policy:git-bb96264@sha256:1bc02bc28a9eb029a152016a507800397acd7853f1f8866592ca0eb59593cec1
+    - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6

--- a/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
@@ -30,7 +30,7 @@ spec:
         - github.com/release-engineering/rhtap-ec-policy//data
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       policy:
-        - oci::quay.io/enterprise-contract/ec-release-policy:git-fab6481@sha256:757440524b5312a14170ee688e21e973fb1b9510a6a0ed862aabd4957d392f4d
+        - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6
       ruleData:
         allowed_registry_prefixes:
           # These are the defaults

--- a/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/ec-policy.yaml
@@ -18,7 +18,7 @@ spec:
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
-      - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
+      - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: EnterpriseContractPolicy
@@ -41,4 +41,4 @@ spec:
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
-      - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
+      - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6

--- a/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/ec-policy.yaml
@@ -19,7 +19,7 @@ spec:
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
-      - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
+      - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: EnterpriseContractPolicy

--- a/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/ec-policy.yaml
@@ -16,4 +16,4 @@ spec:
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
-      - oci::quay.io/enterprise-contract/ec-release-policy:git-2f48179@sha256:ba89f48bfac5750e9e105e4d158f371c99fd8d407090cd1cdcfba9ebb1c6549e
+      - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy-o11y.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy-o11y.yaml
@@ -26,4 +26,4 @@ spec:
         - github.com/release-engineering/rhtap-ec-policy//data
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       policy:
-        - oci::quay.io/enterprise-contract/ec-release-policy:git-bb96264@sha256:1bc02bc28a9eb029a152016a507800397acd7853f1f8866592ca0eb59593cec1
+        - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy.yaml
@@ -20,4 +20,4 @@ spec:
         - github.com/release-engineering/rhtap-ec-policy//data
         - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
       policy:
-        - oci::quay.io/enterprise-contract/ec-release-policy:git-bb96264@sha256:1bc02bc28a9eb029a152016a507800397acd7853f1f8866592ca0eb59593cec1
+        - oci::quay.io/enterprise-contract/ec-release-policy:git-8229928@sha256:0e697db0d42416a23a58cc52597057dd12f7eb71bd8930c95564706126c15df6


### PR DESCRIPTION
Updates all image references, apart from the ones with the `latest` tag to the currently latest version of EC release policy.