### PR TITLE
Revert "rhtap-build workspace: link pull secret to SA"

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/v1_serviceaccount_appstudio-pipeline.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/v1_serviceaccount_appstudio-pipeline.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-imagePullSecrets:
-- name: registry-redhat-io-pull-secret
-kind: ServiceAccount
-metadata:
-  name: appstudio-pipeline
-  namespace: rhtap-build-tenant
-secrets:
-- name: registry-redhat-io-pull-secret

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/kustomization.yaml
@@ -2,7 +2,6 @@ resources:
 - release_plan.yaml
 - external-secrets
 - integration_test_scenario.yaml
-- service_account.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/service_account.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/service_account.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: appstudio-pipeline
-  namespace: rhtap-build-tenant
-secrets:
-  - name: registry-redhat-io-pull-secret
-imagePullSecrets:
-  - name: registry-redhat-io-pull-secret


### PR DESCRIPTION
This repository is not allowed to manage service accounts

    resource :ServiceAccount is not permitted in project tenants-config

Will link the registry pull secret manually.

This reverts commit 8d7f60e95862f48563195c6f087416ef909884e6.