### PR TITLE
Add releaseplan for Maestro

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/appstudio.redhat.com_v1alpha1_releaseplan_maestro-rhtap-releaseplan.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/appstudio.redhat.com_v1alpha1_releaseplan_maestro-rhtap-releaseplan.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: maestro-rhtap-tenant
 spec:
   application: maestro
-  target: maestro-prod-index
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/appstudio.redhat.com_v1alpha1_releaseplan_maestro-rhtap-releaseplan.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/appstudio.redhat.com_v1alpha1_releaseplan_maestro-rhtap-releaseplan.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: maestro-rhtap-releaseplan
+  namespace: maestro-rhtap-tenant
+spec:
+  application: maestro
+  target: maestro-prod-index

--- a/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release-plan.yaml
+namespace: maestro-rhtap-tenant

--- a/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/release-plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/release-plan.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: maestro-rhtap-releaseplan
+spec:
+  application: maestro
+  target: maestro-prod-index

--- a/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/release-plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/maestro-rhtap-tenant/release-plan.yaml
@@ -8,4 +8,4 @@ metadata:
   name: maestro-rhtap-releaseplan
 spec:
   application: maestro
-  target: maestro-prod-index
+  target: rhtap-releng-tenant


### PR DESCRIPTION
## Summary

This PR adds a ReleasePlan for Maestro to reference the newly-created RPA for maestro from https://gitlab.cee.redhat.com/releng/rhtap-release-data/-/merge_requests/179