### PR TITLE
chore: enable tools component's tenant configs

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-tools-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-tools-rpa.yaml
@@ -1,0 +1,34 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+  name: rhtap-tools-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+spec:
+  applications:
+  - tools
+  data:
+    images:
+      addGitShaTag: true
+      defaultTag: latest
+    mapping:
+      components:
+      - name: tools
+        repository: quay.io/redhat-appstudio/tools
+    pyxis:
+      secret: pyxis-production-secret
+      server: production
+  origin: rhtap-o11y-tenant
+  pipeline:
+    pipelineRef:
+      params:
+      - name: url
+        value: https://github.com/redhat-appstudio/release-service-catalog.git
+      - name: revision
+        value: production
+      - name: pathInRepo
+        value: pipelines/rhtap-service-push/rhtap-service-push.yaml
+      resolver: git
+    serviceAccountName: rhtap-servicerelease-sa
+  policy: rh-policy

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1alpha1_releaseplan_tools-release-to-quay-konflux-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1alpha1_releaseplan_tools-release-to-quay-konflux-ser.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: tools-release-to-quay-konflux-ser
+  namespace: rhtap-o11y-tenant
+spec:
+  application: tools
+  displayName: tools release-to-quay
+  target: rh-managed-rhtap-ser-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tools-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tools-enterprise-contract.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: tools-enterprise-contract
+  namespace: rhtap-o11y-tenant
+spec:
+  application: tools
+  contexts:
+  - description: Application testing
+    name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rh-managed-rhtap-ser-tenant/rh-policy
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - release_plan_admission-internal-services.yaml
 - release_plan_admission-release-service.yaml
 - release_plan_admission-segment-bridge.yaml
+- release_plan_admission-tools.yaml
 - release_plan_admission-remotesecret.yaml
 - release_plan_admission-spi.yaml
 - release_plan_admission-build-trusted-artifacts.yaml

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-tools.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-tools.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlanAdmission
+metadata:
+  name: rhtap-tools-rpa
+  namespace: rh-managed-rhtap-ser-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+spec:
+  applications:
+    - tools
+  data:
+    images:
+      addGitShaTag: true
+      defaultTag: latest
+    mapping:
+      components:
+        - name: tools
+          repository: "quay.io/redhat-appstudio/tools"
+    pyxis:
+      secret: pyxis-production-secret
+      server: production
+  origin: rhtap-o11y-tenant
+  pipeline:
+    pipelineRef:
+      resolver: git
+      params:
+        - name: url
+          value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+        - name: revision
+          value: production
+        - name: pathInRepo
+          value: "pipelines/rhtap-service-push/rhtap-service-push.yaml"
+    serviceAccountName: rhtap-servicerelease-sa
+  policy: rh-policy

--- a/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
@@ -40,3 +40,26 @@ spec:
       - name: pathInRepo
         value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
     resolver: git
+---
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: tools-enterprise-contract
+  namespace: rhtap-o11y-tenant
+spec:
+  application: tools
+  contexts:
+    - description: Application testing
+      name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: rh-managed-rhtap-ser-tenant/rh-policy
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/build-definitions'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/release_plan.yaml
@@ -21,3 +21,16 @@ metadata:
 spec:
   application: o11y
   target: rh-managed-rhtap-ser-tenant
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: tools-release-to-quay-konflux-ser
+  namespace: rhtap-o11y-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  application: tools
+  displayName: tools release-to-quay
+  target: rh-managed-rhtap-ser-tenant


### PR DESCRIPTION
Enable tools tenant configs so it can be released
by Konflux.