### PR TITLE
feat(RHTAPREL-723): update releaseplan target to releng tenant

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_build-service-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_build-service-release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-build-tenant
 spec:
   application: build
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_build-trusted-artifacts-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_build-trusted-artifacts-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-build-tenant
 spec:
   application: build-trusted-artifacts
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_image-controller-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_image-controller-release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-build-tenant
 spec:
   application: image-controller
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-gitops-tenant
 spec:
   application: external-secrets
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/appstudio.redhat.com_v1alpha1_releaseplan_application-service-release-to-quay-konflux-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/appstudio.redhat.com_v1alpha1_releaseplan_application-service-release-to-quay-konflux-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-has-tenant
 spec:
   application: application-service
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1alpha1_releaseplan_integration-service-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1alpha1_releaseplan_integration-service-release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-integration-tenant
 spec:
   application: integration-service
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1alpha1_releaseplan_o11y-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1alpha1_releaseplan_o11y-release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-o11y-tenant
 spec:
   application: o11y
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-o11y-tenant
 spec:
   application: segment-bridge
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1alpha1_releaseplan_tools-release-to-quay-konflux-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1alpha1_releaseplan_tools-release-to-quay-konflux-ser.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   application: tools
   displayName: tools release-to-quay
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1alpha1_releaseplan_internal-services-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1alpha1_releaseplan_internal-services-release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-release-2-tenant
 spec:
   application: internal-services
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-service-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-service-release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-release-2-tenant
 spec:
   application: release-service
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1alpha1_releaseplan_remotesecret-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1alpha1_releaseplan_remotesecret-release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-spi-tenant
 spec:
   application: remotesecret
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1alpha1_releaseplan_spi-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1alpha1_releaseplan_spi-release-to-quay-rhtap-ser.yaml
@@ -8,4 +8,4 @@ metadata:
   namespace: rhtap-spi-tenant
 spec:
   application: spi
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
@@ -8,7 +8,7 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: build
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
@@ -20,7 +20,7 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: image-controller
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
@@ -32,7 +32,7 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: build-trusted-artifacts
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan

--- a/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/release_plan.yaml
@@ -8,4 +8,4 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: external-secrets
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/release_plan.yaml
@@ -8,4 +8,4 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: application-service
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/release_plan.yaml
@@ -8,4 +8,4 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: integration-service
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/release_plan.yaml
@@ -8,7 +8,7 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: segment-bridge
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
@@ -20,7 +20,7 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: o11y
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
@@ -33,4 +33,4 @@ metadata:
 spec:
   application: tools
   displayName: tools release-to-quay
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/release_plan.yaml
@@ -8,7 +8,7 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: release-service
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
@@ -20,4 +20,4 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: internal-services
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/release_plan.yaml
@@ -8,7 +8,7 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: remotesecret
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
@@ -20,4 +20,4 @@ metadata:
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
   application: spi
-  target: rh-managed-rhtap-ser-tenant
+  target: rhtap-releng-tenant


### PR DESCRIPTION
- As part of this commit targets for RPA are updated
to point to the new location, `rhtap-releng-tenant.`

- At this point, all the RPA has already migrated to
a new location.

- Ref: Migration [MR](https://gitlab.cee.redhat.com/releng/rhtap-release-data/-/merge_requests/145)

- Jira: [RHTAPREL-723](https://issues.redhat.com/browse/RHTAPREL-723)