### PR TITLE
ROX-22546: create ReleasePlan for RHACS

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-acs-tenant/appstudio.redhat.com_v1alpha1_releaseplan_rh-acs-fast-stream.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-acs-tenant/appstudio.redhat.com_v1alpha1_releaseplan_rh-acs-fast-stream.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "false"
+    release.appstudio.openshift.io/standing-attribution: "false"
+  name: rh-acs-fast-stream
+  namespace: rh-acs-tenant
+spec:
+  application: acs
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rh-acs-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-acs-tenant/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - integration_test_scenario.yaml
+- release_plan.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/cluster/stone-prd-rh01/tenants/rh-acs-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-acs-tenant/release_plan.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: rh-acs-fast-stream
+  namespace: rh-acs-tenant
+  labels:
+    # Your application will trigger the release every time a snapshot is created.
+    release.appstudio.openshift.io/auto-release: 'false'
+    # The author of the release plan will be provided as the standing attribution for releases.
+    release.appstudio.openshift.io/standing-attribution: 'false'
+spec:
+  application: acs
+  target: rhtap-releng-tenant


### PR DESCRIPTION
Following the creation of the ReleasePlanAdmission and constraints configuration in https://gitlab.cee.redhat.com/releng/rhtap-release-data/-/merge_requests/195, this shall create the ReleasePlan for ACS. 