### PR TITLE
konflux-infra: make integ ec test optional

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_enterprise-contract.yaml
@@ -1,6 +1,8 @@
 apiVersion: appstudio.redhat.com/v1beta1
 kind: IntegrationTestScenario
 metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "true"
   name: enterprise-contract
   namespace: konflux-infra-tenant
 spec:

--- a/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/integration_test_scenario.yaml
@@ -2,6 +2,8 @@ apiVersion: appstudio.redhat.com/v1beta1
 kind: IntegrationTestScenario
 metadata:
   name: enterprise-contract
+  labels:
+    test.appstudio.openshift.io/optional: "true"
 spec:
   application: repository-validator
   contexts:


### PR DESCRIPTION
It currently using a policy that differs from te policy we use for the release (which is more permissive).

Make it optional so we can improve as build as we go without blocking the release.