### PR TITLE
feat: add release e2e SA

### DIFF
--- a/auto-generated/cluster/stone-stg-rh01/managed/managed-release-team-tenant/appstudio.redhat.com_v1beta1_remotesecret_registry-redhat-io-quay-token-secret-remote-secret.yaml
+++ b/auto-generated/cluster/stone-stg-rh01/managed/managed-release-team-tenant/appstudio.redhat.com_v1beta1_remotesecret_registry-redhat-io-quay-token-secret-remote-secret.yaml
@@ -9,6 +9,9 @@ spec:
     - serviceAccount:
         reference:
           name: rh-push-to-registry-redhat-io-sa
+    - serviceAccount:
+        reference:
+          name: release-e2e-sa
     name: quay-token-secret
     type: kubernetes.io/dockerconfigjson
   targets:

--- a/auto-generated/cluster/stone-stg-rh01/managed/managed-release-team-tenant/rbac.authorization.k8s.io_v1_rolebinding_managed-release-team-tenant-release-service-pipeline-rolebinding-managed.yaml
+++ b/auto-generated/cluster/stone-stg-rh01/managed/managed-release-team-tenant/rbac.authorization.k8s.io_v1_rolebinding_managed-release-team-tenant-release-service-pipeline-rolebinding-managed.yaml
@@ -11,3 +11,6 @@ subjects:
 - kind: ServiceAccount
   name: rh-push-to-registry-redhat-io-sa
   namespace: managed-release-team-tenant
+- kind: ServiceAccount
+  name: release-e2e-sa
+  namespace: managed-release-team-tenant

--- a/auto-generated/cluster/stone-stg-rh01/managed/managed-release-team-tenant/v1_serviceaccount_release-e2e-sa.yaml
+++ b/auto-generated/cluster/stone-stg-rh01/managed/managed-release-team-tenant/v1_serviceaccount_release-e2e-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-e2e-sa
+  namespace: managed-release-team-tenant

--- a/cluster/stone-stg-rh01/managed/managed-release-team-tenant/kustomization.yaml
+++ b/cluster/stone-stg-rh01/managed/managed-release-team-tenant/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - release-service-account-rb.yaml
 - persistent-volume-claim.yaml
 - release-pipeline-sa.yaml
+- release-e2e-sa.yaml
 - remote-secrets
 
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/cluster/stone-stg-rh01/managed/managed-release-team-tenant/release-e2e-sa.yaml
+++ b/cluster/stone-stg-rh01/managed/managed-release-team-tenant/release-e2e-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-e2e-sa
+  namespace: managed-release-team-tenant

--- a/cluster/stone-stg-rh01/managed/managed-release-team-tenant/release-service-account-rb.yaml
+++ b/cluster/stone-stg-rh01/managed/managed-release-team-tenant/release-service-account-rb.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: ServiceAccount
     name: rh-push-to-registry-redhat-io-sa
     namespace: managed-release-team-tenant
+  - kind: ServiceAccount
+    name: release-e2e-sa
+    namespace: managed-release-team-tenant

--- a/cluster/stone-stg-rh01/managed/managed-release-team-tenant/remote-secrets/remote_secret-quay-token.yaml
+++ b/cluster/stone-stg-rh01/managed/managed-release-team-tenant/remote-secrets/remote_secret-quay-token.yaml
@@ -11,5 +11,8 @@ spec:
       - serviceAccount:
           reference:
             name: rh-push-to-registry-redhat-io-sa
+      - serviceAccount:
+          reference:
+            name: release-e2e-sa
   targets:
     - namespace: managed-release-team-tenant


### PR DESCRIPTION
A new SA is required to run Release E2E tests.