### PR TITLE
Add awood1-tenant for development on insights integration testing

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-enterprise-contract.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: rhsm-subscriptions-enterprise-contract
+  namespace: awood1-tenant
+spec:
+  application: rhsm-subscriptions
+  contexts:
+  - description: Application testing
+    name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/app-interface-standard
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+    resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-tekton-insights.yaml
@@ -1,0 +1,29 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "false"
+  name: rhsm-subscriptions-tekton-insights
+  namespace: awood1-tenant
+spec:
+  application: rhsm-subscriptions
+  params:
+  - name: APP_NAME
+    value: rhsm
+  - name: COMPONENTS_W_RESOURCES
+    value: app:rhsm
+  - name: COMPONENT_NAME
+    value: rhsm
+  - name: IQE_PLUGINS
+    value: rhsm-subscriptions
+  - name: IQE_MARKER_EXPRESSION
+    value: ephemeral
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/gbenhaim/tekton-insights.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/basic.yaml
+    resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: app-interface
+  namespace: awood1-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: production/redhat/app-interface
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: app-interface

--- a/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: consoledot-ephemeral-env-provider
+  namespace: awood1-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: production/redhat/consoledot-ephemeral-env-provider
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ephemeral-env-provider

--- a/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: rh-artifacts-bucket-writer
+  namespace: awood1-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: ""
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: rh-artifacts-bucket-writer-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rh-artifacts-bucket

--- a/cluster/stone-prd-rh01/tenants/awood1-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/awood1-tenant/integration_test_scenario.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: rhsm-subscriptions-enterprise-contract
+  namespace: awood1-tenant
+spec:
+  application: rhsm-subscriptions
+  contexts:
+    - description: Application testing
+      name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: rhtap-releng-tenant/app-interface-standard
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/build-definitions'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/awood1-tenant/integration_test_tekton.yaml
+++ b/cluster/stone-prd-rh01/tenants/awood1-tenant/integration_test_tekton.yaml
@@ -1,0 +1,66 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "false" # Change to "true" if you don't need the test to be mandatory
+  name: rhsm-subscriptions-tekton-insights
+  namespace: awood1-tenant
+spec:
+  application: rhsm-subscriptions
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+
+    - name: revision
+      value: main # Or whatever branch you want to test
+
+    - name: pathInRepo
+      value: pipelines/basic.yaml # This is the path to the pipeline
+    resolver: git
+  params:
+    - name: APP_NAME
+      # Name of app-sre "application" folder this component lives in.
+      value: rhsm
+
+    # - name: COMPONENTS
+    #   # Space-separated list of components to load.
+    #   value: # Bonfire default is all components
+
+    - name: COMPONENTS_W_RESOURCES
+      # List of components to keep.
+      value: app:rhsm
+
+      #IMPORTANT: Your component in RHTAP has to be named the same as this field.
+    - name: COMPONENT_NAME
+      # Name of app-sre "resourceTemplate" in deploy.yaml for this component.
+      value: rhsm
+
+    - name: IQE_PLUGINS
+      # Name of the IQE plugin for this app.
+      value: rhsm-subscriptions
+
+    - name: IQE_MARKER_EXPRESSION
+      # This is the value passed to pytest -m. Default is ""
+      value: ephemeral
+
+    # - name: IQE_FILTER_EXPRESSION
+    #   value: # This is the value passed to pytest -k. Default is "" when no filter desired
+
+    # - name: IQE_REQUIREMENTS
+    #   value: # "something,something_else" -- iqe requirements filter. Default is "" when no filter desired
+
+    # - name: IQE_REQUIREMENTS_PRIORITY
+    #   value: # "something,something_else" -- iqe requirements priority filter. Default is "" when no filter desired
+
+    # - name: IQE_TEST_IMPORTANCE
+    #   value: # "something,something_else" -- iqe test importance filter. Default is "" when no filter desired
+
+    # - name: IQE_CJI_TIMEOUT
+    #   value: # Timeout value to pass to 'oc wait', should be slightly higher than expected test run time. Default is 30m
+
+    # - name: IQE_ENV
+    #   value: # "something" -- value to set for ENV_FOR_DYNACONF. Default is "clowder_smoke"
+
+    # - name: IQE_SELENIUM
+    #   value: # Whether to run IQE pod with a selenium container. Default is "false"

--- a/cluster/stone-prd-rh01/tenants/awood1-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/awood1-tenant/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - integration_test_scenario.yaml
+  - integration_test_tekton.yaml
+  - ../../../../lib/consoledot-test-pipeline
+namespace: awood1-tenant


### PR DESCRIPTION
I'm looking to work on some modifications to the `tekton-insights` platform and want to be able to deploy to an actual environment.