### PR TITLE
Stop using deprecated EC pipelines

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_notifications-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_notifications-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-sc-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-sc-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_playbook-dispatcher-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_playbook-dispatcher-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_storage-broker-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_storage-broker-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_enterprise-contract.yaml
@@ -17,5 +17,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_multiarch-tuning-operator-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_multiarch-tuning-operator-enterprise-contract.yaml
@@ -15,5 +15,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-acs-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_acs-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-acs-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_acs-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-trex-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-trex-tenant-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-trex-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-trex-tenant-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-11-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-11-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-12-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-12-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-13-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-13-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-14-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-14-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-15-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-15-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-trusted-artifacts-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-trusted-artifacts-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_image-controller-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_image-controller-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-syft-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-syft-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_external-secrets-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_external-secrets-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_application-service-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_application-service-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_integration-service-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_integration-service-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhtap-consoledot-frontend-build-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhtap-consoledot-frontend-build-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_o11y-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_o11y-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_project-controller-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_project-controller-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_segment-bridge-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_segment-bridge-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tools-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tools-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_workspace-manager-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_workspace-manager-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_internal-services-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_internal-services-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_release-service-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_release-service-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_remotesecret-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_remotesecret-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_spi-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_spi-enterprise-contract.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ecosystem-images-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ecosystem-images-enterprise-contract.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
   - description: Application testing
     name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
     - name: url
@@ -15,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/notifications-enterprise-contract_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/notifications-enterprise-contract_integration_test.yaml
@@ -18,5 +18,5 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+      value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/ingress_sc_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/ingress_sc_integration_test.yaml
@@ -8,7 +8,7 @@ spec:
   contexts:
     - description: Application testing
       name: application
-  params: 
+  params:
     - name: POLICY_CONFIGURATION
       value: rhtap-releng-tenant/app-interface-standard
   resolverRef:
@@ -18,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/integration_test_scenario.yaml
@@ -8,7 +8,7 @@ spec:
   contexts:
     - description: Application testing
       name: application
-  params: 
+  params:
     - name: POLICY_CONFIGURATION
       value: rhtap-releng-tenant/app-interface-standard
   resolverRef:
@@ -18,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/playbook_dispatcher_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/playbook_dispatcher_integration_test.yaml
@@ -8,7 +8,7 @@ spec:
   contexts:
     - description: Application testing
       name: application
-  params: 
+  params:
     - name: POLICY_CONFIGURATION
       value: rhtap-releng-tenant/app-interface-standard
   resolverRef:
@@ -18,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/storage_broker_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/storage_broker_integration_test.yaml
@@ -8,7 +8,7 @@ spec:
   contexts:
     - description: Application testing
       name: application
-  params: 
+  params:
     - name: POLICY_CONFIGURATION
       value: rhtap-releng-tenant/app-interface-standard
   resolverRef:
@@ -18,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/integration_test_scenario.yaml
@@ -16,5 +16,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/integration_test_scenario.yaml
@@ -15,5 +15,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rh-acs-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-acs-tenant/integration_test_scenario.yaml
@@ -15,7 +15,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
   params:
   - name: POLICY_CONFIGURATION

--- a/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/integration_test_scenario.yaml
@@ -18,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rh-trex-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-trex-tenant/integration_test_scenario.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
       - name: url
@@ -15,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/rhbk-fbc-enterprise-contract.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/rhbk-fbc-enterprise-contract.yaml
@@ -16,7 +16,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
   params:
   - name: POLICY_CONFIGURATION
@@ -39,7 +39,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
   params:
   - name: POLICY_CONFIGURATION
@@ -62,7 +62,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
   params:
   - name: POLICY_CONFIGURATION
@@ -85,7 +85,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
   params:
   - name: POLICY_CONFIGURATION
@@ -108,7 +108,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
   params:
   - name: POLICY_CONFIGURATION

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
       - name: url
@@ -15,7 +18,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
 ---
 apiVersion: appstudio.redhat.com/v1beta1
@@ -28,6 +31,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
       - name: url
@@ -35,7 +41,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
 ---
 apiVersion: appstudio.redhat.com/v1beta1
@@ -48,6 +54,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
       - name: url
@@ -55,7 +64,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
 ---
 apiVersion: appstudio.redhat.com/v1beta1
@@ -68,6 +77,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat
   resolverRef:
     params:
       - name: url
@@ -75,5 +87,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/integration_test_scenario.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
       - name: url
@@ -15,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/integration_test_scenario.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
       - name: url
@@ -15,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/integration_test_scenario.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
       - name: url
@@ -15,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/integration_test_scenario_consoledot_frontend.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/integration_test_scenario_consoledot_frontend.yaml
@@ -8,7 +8,7 @@ spec:
   contexts:
     - description: Application testing
       name: application
-  params: 
+  params:
     - name: POLICY_CONFIGURATION
       value: consoledot-frontend-standard
   resolverRef:
@@ -18,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
       - name: url
@@ -15,7 +18,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
 ---
 apiVersion: appstudio.redhat.com/v1beta1
@@ -38,7 +41,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
 ---
 apiVersion: appstudio.redhat.com/v1beta1
@@ -61,7 +64,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
 ---
 apiVersion: appstudio.redhat.com/v1beta1
@@ -84,7 +87,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
 ---
 apiVersion: appstudio.redhat.com/v1beta1
@@ -107,5 +110,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/integration_test_scenario.yaml
@@ -18,7 +18,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
 ---
 apiVersion: appstudio.redhat.com/v1beta1
@@ -41,5 +41,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/integration_test_scenario.yaml
@@ -18,7 +18,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git
 ---
 apiVersion: appstudio.redhat.com/v1beta1
@@ -41,5 +41,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git

--- a/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/integration_test_scenario_ecosystem.yaml
+++ b/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/integration_test_scenario_ecosystem.yaml
@@ -8,6 +8,9 @@ spec:
   contexts:
     - description: Application testing
       name: application
+  params:
+    - name: POLICY_CONFIGURATION
+      value: enterprise-contract-service/redhat-no-hermetic
   resolverRef:
     params:
       - name: url
@@ -15,5 +18,5 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/enterprise-contract-redhat-no-hermetic.yaml
+        value: pipelines/enterprise-contract.yaml
     resolver: git


### PR DESCRIPTION
In the build-definitions repo, there are 5 different enterprise-contract pipelines. In a previous generation of Konflux, it was not possible to set Pipeline parameters in an IntegrationTestScenario. For this reason, copies of the enterprise-contract Pipeline were introduced. The only difference between them being the default value of the `POLICY_CONFIGURATION` parameter.

As captured in EC-330, we want to undo this workaround for various reasons. The most pressing one being that having to test the different variations of the Pipeline is time consuming and significantly slows down e2e tests.

This commit changes all the IntegrationTestScenarios to use the main enterprise-contract Pipeline, `enterprise-contract.yaml`. In most cases, the `POLICY_CONFIGURATION` parameter was already overwritten. Simply changing the Pipeline should yield the same result. In the other cases, the `POLICY_CONFIGURATION` parameter is now added with the corresponding value.