### PR TITLE
chore: prepare tekton-insights migration to new org

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-tekton-insights.yaml
@@ -21,7 +21,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/ergonzale-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-operator-gathering-conditions-service-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/ergonzale-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-operator-gathering-conditions-service-tekton-insights.yaml
@@ -37,7 +37,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/ergonzale-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ros-ocp-backend-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/ergonzale-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ros-ocp-backend-tekton-insights.yaml
@@ -37,7 +37,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/gbenhaim-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_provisioning-backend-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/gbenhaim-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_provisioning-backend-tekton-insights.yaml
@@ -37,7 +37,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/gbenhaim-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/gbenhaim-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tekton-insights.yaml
@@ -37,7 +37,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_cloud-connector-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_cloud-connector-tekton-insights.yaml
@@ -26,7 +26,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_export-service-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_export-service-tekton-insights.yaml
@@ -28,7 +28,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-sc-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-sc-tekton-insights.yaml
@@ -24,7 +24,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-tekton-insights.yaml
@@ -22,7 +22,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_playbook-dispatcher-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_playbook-dispatcher-tekton-insights.yaml
@@ -26,7 +26,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_storage-broker-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_storage-broker-tekton-insights.yaml
@@ -24,7 +24,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-ccx-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-content-template-renderer-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-ccx-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-content-template-renderer-tekton-insights.yaml
@@ -27,7 +27,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-devprod-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ingress-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-devprod-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ingress-tekton-insights.yaml
@@ -23,7 +23,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-hms-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-hms-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tekton-insights.yaml
@@ -21,7 +21,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-tekton-insights.yaml
@@ -21,7 +21,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1alpha1_component_tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1alpha1_component_tekton-insights.yaml
@@ -14,4 +14,4 @@ spec:
       context: ./
       dockerfileUrl: Dockerfile
       revision: main
-      url: https://github.com/gbenhaim/tekton-insights.git
+      url: https://github.com/RedHatInsights/bonfire-tekton.git

--- a/cluster/stone-prd-rh01/tenants/awood1-tenant/integration_test_tekton.yaml
+++ b/cluster/stone-prd-rh01/tenants/awood1-tenant/integration_test_tekton.yaml
@@ -10,7 +10,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+      value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
 
     - name: revision
       value: main # Or whatever branch you want to test

--- a/cluster/stone-prd-rh01/tenants/ergonzale-tenant/insights-gathering-conditions.yaml
+++ b/cluster/stone-prd-rh01/tenants/ergonzale-tenant/insights-gathering-conditions.yaml
@@ -9,7 +9,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main # Or whatever branch you want to test
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/ergonzale-tenant/ros-ocp-backend.yaml
+++ b/cluster/stone-prd-rh01/tenants/ergonzale-tenant/ros-ocp-backend.yaml
@@ -9,7 +9,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main # Or whatever branch you want to test
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/gbenhaim-tenant/ccx-integ-test.yaml
+++ b/cluster/stone-prd-rh01/tenants/gbenhaim-tenant/ccx-integ-test.yaml
@@ -9,7 +9,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main # Or whatever branch you want to test
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/gbenhaim-tenant/provisioning-backend-test.yaml
+++ b/cluster/stone-prd-rh01/tenants/gbenhaim-tenant/provisioning-backend-test.yaml
@@ -9,7 +9,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main # Or whatever branch you want to test
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/notifications-tekton-insights_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/notifications-tekton-insights_integration_test.yaml
@@ -13,7 +13,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/cloud_connector_tekton_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/cloud_connector_tekton_test.yaml
@@ -13,7 +13,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/export_service_tekton_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/export_service_tekton_test.yaml
@@ -13,7 +13,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/ingress_sc_tekton_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/ingress_sc_tekton_test.yaml
@@ -13,7 +13,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/integration_test_tekton.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/integration_test_tekton.yaml
@@ -13,7 +13,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/playbook_dispatcher_tekton_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/playbook_dispatcher_tekton_test.yaml
@@ -13,7 +13,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/storage_broker_tekton_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/storage_broker_tekton_test.yaml
@@ -13,7 +13,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+        value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rh-ccx-tenant/insights-content-template-renderer.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-ccx-tenant/insights-content-template-renderer.yaml
@@ -10,7 +10,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+      value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
     - name: revision
       value: main # Or whatever branch you want to test
     - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rh-devprod-tenant/devprod-integration-test.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-devprod-tenant/devprod-integration-test.yaml
@@ -10,7 +10,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+      value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
     - name: revision
       value: main # Or whatever branch you want to test
     - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rh-hms-tenant/provisioning-backend-integration.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-hms-tenant/provisioning-backend-integration.yaml
@@ -10,7 +10,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+      value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
     - name: revision
       value: main # Or whatever branch you want to test
     - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/integration_test_tekton.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/integration_test_tekton.yaml
@@ -10,7 +10,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/gbenhaim/tekton-insights.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
+      value: https://github.com/RedHatInsights/bonfire-tekton.git # Temporary on gbenhaim's org. Also, you can fork it and reference yours here.
 
     - name: revision
       value: main # Or whatever branch you want to test

--- a/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/tekton-insights.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/tekton-insights.yaml
@@ -19,6 +19,6 @@ spec:
   source:
     git:
       revision: main
-      url: https://github.com/gbenhaim/tekton-insights.git
+      url: https://github.com/RedHatInsights/bonfire-tekton.git
       dockerfileUrl: Dockerfile
       context: ./


### PR DESCRIPTION
The tekton-insights repo has been migrated to https://github.com/RedHatInsights/bonfire-tekton, so we are changing all references to that repo