### PR TITLE
feat(RELEASE-500): update release service catalog reference to konflux-ci

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_bootc-image-builder.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_bootc-image-builder.yaml
@@ -22,7 +22,7 @@ spec:
     pipelineRef:
       params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: production
       - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_centos-bootc.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_centos-bootc.yaml
@@ -22,7 +22,7 @@ spec:
     pipelineRef:
       params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: production
       - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_fedora-bootc.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_fedora-bootc.yaml
@@ -22,7 +22,7 @@ spec:
     pipelineRef:
       params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: production
       - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_fbc-staged-index-release-v4-15-plus.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_fbc-staged-index-release-v4-15-plus.yaml
@@ -26,7 +26,7 @@ spec:
     pipelineRef:
       params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: production
       - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_fbc-staged-index-release.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_fbc-staged-index-release.yaml
@@ -28,7 +28,7 @@ spec:
     pipelineRef:
       params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: production
       - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_hypershift-operator-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_hypershift-operator-rpa.yaml
@@ -25,7 +25,7 @@ spec:
     pipelineRef:
       params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: production
       - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-trusted-artifacts-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-trusted-artifacts-rpa.yaml
@@ -27,7 +27,7 @@ spec:
     pipelineRef:
       params:
       - name: url
-        value: https://github.com/redhat-appstudio/release-service-catalog.git
+        value: https://github.com/konflux-ci/release-service-catalog.git
       - name: revision
         value: production
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/release-plan-admission/bootc-image-builder.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/release-plan-admission/bootc-image-builder.yaml
@@ -24,7 +24,7 @@ spec:
       resolver: git
       params:
         - name: url
-          value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
           value: production
         - name: pathInRepo

--- a/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/release-plan-admission/centos-bootc.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/release-plan-admission/centos-bootc.yaml
@@ -24,7 +24,7 @@ spec:
       resolver: git
       params:
         - name: url
-          value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
           value: production
         - name: pathInRepo

--- a/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/release-plan-admission/fedora-bootc.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/release-plan-admission/fedora-bootc.yaml
@@ -24,7 +24,7 @@ spec:
       resolver: git
       params:
         - name: url
-          value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
           value: production
         - name: pathInRepo

--- a/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/release_plan_admission_stage_index.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/release_plan_admission_stage_index.yaml
@@ -28,7 +28,7 @@ spec:
       resolver: git
       params:
         - name: url
-          value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
           value: production
         - name: pathInRepo

--- a/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/release_plan_admission_stage_index_v4_15_plus.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/release_plan_admission_stage_index_v4_15_plus.yaml
@@ -26,7 +26,7 @@ spec:
       resolver: git
       params:
         - name: url
-          value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
           value: production
         - name: pathInRepo

--- a/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/release_plan_admission.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/release_plan_admission.yaml
@@ -38,7 +38,7 @@ spec:
       resolver: git
       params:
         - name: url
-          value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
           value: production
         - name: pathInRepo

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-build-trusted-artifacts.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-build-trusted-artifacts.yaml
@@ -29,7 +29,7 @@ spec:
       resolver: git
       params:
         - name: url
-          value: "https://github.com/redhat-appstudio/release-service-catalog.git"
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: revision
           value: production
         - name: pathInRepo


### PR DESCRIPTION
 This commit updates the `release-service catalog` reference
 as result of migration to `konflux-ci` from `redhat-appstudio`
 more details parent EPIC:
 https://issues.redhat.com/browse/RHTAPREL-800