### PR TITLE
Onboard the Maestro Project as part of ACM via Configuration-as-Code

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_application_maestro-main.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_application_maestro-main.yaml
@@ -1,0 +1,8 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: maestro-main
+  namespace: crt-redhat-acm-tenant
+spec:
+  description: maestro
+  displayName: maestro

--- a/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_component_maestro-addon-main.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_component_maestro-addon-main.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: "true"
+  name: maestro-addon-main
+  namespace: crt-redhat-acm-tenant
+spec:
+  application: maestro-main
+  componentName: maestro-addon
+  source:
+    git:
+      context: ./
+      dockerfileUrl: Dockerfile
+      revision: main
+      url: https://github.com/stolostron/maestro-addon
+  targetPort: 8080

--- a/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_component_maestro-main.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_component_maestro-main.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: "true"
+  name: maestro-main
+  namespace: crt-redhat-acm-tenant
+spec:
+  application: maestro-main
+  componentName: maestro
+  source:
+    git:
+      context: ./
+      dockerfileUrl: Containerfile.rhtap
+      revision: main
+      url: https://github.com/stolostron/maestro
+  targetPort: 8080

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - release-plan.yaml
+  - maestro/overlay/maestro/main/
 namespace: crt-redhat-acm-tenant

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/README.md
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/README.md
@@ -1,0 +1,3 @@
+# RHTAP Migration for CasC
+
+Building out this repository to serve as both an example and information hub on creating new konflux applications using `kustomize`

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/base/component.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/base/component.yaml
@@ -1,0 +1,18 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    image.redhat.com/generate: "true"
+    appstudio.openshift.io/pac-provision: request
+    build.appstudio.openshift.io/request: configure-pac
+  name: example-component
+spec:
+  componentName: example-component
+  application: appName
+  targetPort: 8080
+  source:
+      git:
+        url: gitUrl
+        context: ./
+        dockerfileUrl: ContainerFileLocation
+        revision: defaultBranch

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/base/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+  
+resources:
+  - component.yaml

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/application.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/application.yaml
@@ -1,0 +1,7 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: base
+spec:
+  description: base
+  displayName: base

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+  
+resources:
+  - application.yaml
+  - maestro
+  - maestro-addon

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/maestro-addon/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/maestro-addon/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+  
+resources:
+  - ../../../../base # Path to base component
+
+patches:
+  - path: maestro-addon.yaml # Path to Override File
+    target:
+      kind: Component

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/maestro-addon/maestro-addon.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/maestro-addon/maestro-addon.yaml
@@ -1,0 +1,12 @@
+- op: replace
+  path: /metadata/name
+  value: maestro-addon
+- op: replace
+  path: /spec/componentName
+  value: maestro-addon
+- op: replace
+  path: /spec/source/git/url
+  value: https://github.com/stolostron/maestro-addon
+- op: replace
+  path: /spec/source/git/dockerfileUrl
+  value: "Dockerfile"

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/maestro/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/maestro/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+  
+resources:
+  - ../../../../base # Path to base component
+
+patches:
+  - path: maestro.yaml # Path to Override File
+    target:
+      kind: Component

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/maestro/maestro.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/base/maestro/maestro.yaml
@@ -1,0 +1,12 @@
+- op: replace
+  path: /metadata/name
+  value: maestro
+- op: replace
+  path: /spec/componentName
+  value: maestro
+- op: replace
+  path: /spec/source/git/url
+  value: https://github.com/stolostron/maestro
+- op: replace
+  path: /spec/source/git/dockerfileUrl
+  value: "Containerfile.rhtap"

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/main/application-patch.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/main/application-patch.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: maestro
+- op: replace
+  path: /spec/description
+  value: "maestro"
+- op: replace
+  path: /spec/displayName
+  value: "maestro"

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/main/component-patch.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/main/component-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/application
+  value: maestro-main # Must match /metadata/name in application-patch.yaml
+- op: replace
+  path: /spec/source/git/revision
+  value: main # Replace with your target branch for all components

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/main/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro/overlay/maestro/main/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -main # Add a suffix to all resource names in the application for uniqueness
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: Application
+    path: application-patch.yaml
+  - target:
+      kind: Component
+    path: component-patch.yaml


### PR DESCRIPTION
## Summary of Changes

Maestro is being used standalone as a service out of the openshift-online organization.  ACM is maintaining a product fork of this project in stolostron/maestro and maestro-addon (for ACM).  This PR uses the [casc model](https://github.com/konflux-ci/casc-gpt/tree/main) to onboard this application and components.  