### PR TITLE
feat(RHTAPWATCH-869): test new clowder model

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ingress-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ingress-tekton-insights.yaml
@@ -1,0 +1,21 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "true"
+  name: ingress-tekton-insights
+  namespace: rhtap-migration-tenant
+spec:
+  application: insights-ingress-go
+  contexts:
+  - description: Application testing
+    name: application
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/ernesgonzalez33/insights-ingress-go
+    - name: revision
+      value: new-model-clowder
+    - name: pathInRepo
+      value: test_pipeline.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/insights-ingress-go-clowder-test.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/insights-ingress-go-clowder-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "true"
+  namespace: rhtap-migration-tenant
+  name: ingress-tekton-insights
+spec:
+  application: insights-ingress-go
+  contexts:
+    - description: Application testing
+      name: application
+  resolverRef:
+    params:
+      - name: url
+        value: https://github.com/ernesgonzalez33/insights-ingress-go
+      - name: revision
+        value: new-model-clowder
+      - name: pathInRepo
+        value: test_pipeline.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - release-plan.yaml
   - integration_test_scenario_consoledot_frontend.yaml
   - consoledot-frontend-standard-policy.yaml
+  - insights-ingress-go-clowder-test.yaml
 namespace: rhtap-migration-tenant


### PR DESCRIPTION
I'm testing a new model for the Clowder integration for teams to add the parameters in the pipeline in their own repos instead of here