### PR TITLE
Update enterprise-contract for hypershift-operator-main in crt-redhat-acm tenant

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_hypershift-operator-main-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_hypershift-operator-main-enterprise-contract.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: hypershift-operator-main-enterprise-contract
+  namespace: crt-redhat-acm-tenant
+spec:
+  application: hypershift-operator
+  contexts:
+  - description: Application testing
+    name: application
+  params:
+    name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/app-interface-hypershift
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/hypershift-operator-main/enterprise-contract.integrationtestscenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/hypershift-operator-main/enterprise-contract.integrationtestscenario.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: hypershift-operator-main-enterprise-contract
+  namespace: crt-redhat-acm-tenant
+spec:
+  application: hypershift-operator
+  contexts:
+    - description: Application testing
+      name: application
+  params:
+    name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/app-interface-hypershift
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/build-definitions'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/hypershift-operator-main/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/hypershift-operator-main/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - release-plan.yaml
-  - maestro/overlay/maestro/main/
-  - hypershift-operator-main/
+  - enterprise-contract.integrationtestscenario.yaml
 namespace: crt-redhat-acm-tenant


### PR DESCRIPTION
## Summary of Changes

Update the hypershift-operator-main application IntegrationTestScenario EC to match the custom EC rules gating release as per discussion [here](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1715003115148459).  