### PR TITLE
Create a second SA for konflux-ci releases

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_infra-deployments-pr-creator-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_infra-deployments-pr-creator-remote-secret.yaml
@@ -9,6 +9,9 @@ spec:
     - serviceAccount:
         reference:
           name: konflux-servicerelease-sa
+    - serviceAccount:
+        reference:
+          name: konflux-ci-servicerelease-sa
     name: infra-deployments-pr-creator
     type: Opaque
   targets:

--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_quay-token-konflux-ci-secret-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_quay-token-konflux-ci-secret-remote-secret.yaml
@@ -8,7 +8,7 @@ spec:
     linkedTo:
     - serviceAccount:
         reference:
-          name: konflux-servicerelease-sa
+          name: konflux-ci-servicerelease-sa
     name: quay-token-konflux-ci-secret
     type: kubernetes.io/dockerconfigjson
   targets:

--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_send-slack-notification-secret-remote-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/appstudio.redhat.com_v1beta1_remotesecret_send-slack-notification-secret-remote-secret.yaml
@@ -9,6 +9,9 @@ spec:
     - serviceAccount:
         reference:
           name: konflux-servicerelease-sa
+    - serviceAccount:
+        reference:
+          name: konflux-ci-servicerelease-sa
     name: slack-notification-secret
     type: Opaque
   targets:

--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rbac.authorization.k8s.io_v1_rolebinding_konflux-servicerelease-rb.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rbac.authorization.k8s.io_v1_rolebinding_konflux-servicerelease-rb.yaml
@@ -11,3 +11,6 @@ subjects:
 - kind: ServiceAccount
   name: konflux-servicerelease-sa
   namespace: rhtap-releng-tenant
+- kind: ServiceAccount
+  name: konflux-ci-servicerelease-sa
+  namespace: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/v1_serviceaccount_konflux-ci-servicerelease-sa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/v1_serviceaccount_konflux-ci-servicerelease-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konflux-ci-servicerelease-sa
+  namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-konflux-service-release.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/rb-konflux-service-release.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: ServiceAccount
     name: konflux-servicerelease-sa
     namespace: rhtap-releng-tenant
+  - kind: ServiceAccount
+    name: konflux-ci-servicerelease-sa
+    namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-infra-deployments-pr-creator.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-infra-deployments-pr-creator.yaml
@@ -11,5 +11,8 @@ spec:
       - serviceAccount:
           reference:
             name: konflux-servicerelease-sa
+      - serviceAccount:
+          reference:
+            name: konflux-ci-servicerelease-sa
   targets:
     - namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-quay-token-konflux-ci.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-quay-token-konflux-ci.yaml
@@ -10,6 +10,6 @@ spec:
     linkedTo:
       - serviceAccount:
           reference:
-            name: konflux-servicerelease-sa
+            name: konflux-ci-servicerelease-sa
   targets:
     - namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-send-slack-notification.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/remote-secrets/remote_secret-send-slack-notification.yaml
@@ -11,5 +11,8 @@ spec:
       - serviceAccount:
           reference:
             name: konflux-servicerelease-sa
+      - serviceAccount:
+          reference:
+            name: konflux-ci-servicerelease-sa
   targets:
     - namespace: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/sa-konflux-service-release.yaml
+++ b/cluster/stone-prd-rh01/managed/rhtap-releng-tenant/sa-konflux-service-release.yaml
@@ -1,5 +1,16 @@
+---
+# This SA is linked to remote-secrets/remote_secret-quay-token-konflux-service-release.yaml
+# .. which enables it to write to quay.io/redhat-appstudio
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: konflux-servicerelease-sa
+  namespace: rhtap-releng-tenant
+---
+# This SA is linked to remote-secrets/remote_secret-quay-token-konflux-ci.yaml
+# .. which enables it to write to quay.io/konflux-ci
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konflux-ci-servicerelease-sa
   namespace: rhtap-releng-tenant


### PR DESCRIPTION
There is some bug in `cosign` such that if two secrets are both linked
to push to quay, cosign doesn't know how to sort things out and use the
right one.

To workaround, we need two different serviceaccounts here: one for
pushing to quay.io/redhat-appstudio and one for pushing to
quay.io/konflux-ci.
