### PR TITLE
Run build-service pipelines in rhtap-build-tenant

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets.io_v1beta1_externalsecret_quay-push-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets.io_v1beta1_externalsecret_quay-push-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: quay-push-secret
+  namespace: rhtap-build-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: production/build/tekton-ci/quay-push-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quay-push-secret
+    template:
+      data:
+        .dockerconfigjson: '{{ .config }}'
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
 - infra-deployments-pr-creator.yaml
 - registry-redhat-io-pull-secret.yaml
+- quay-push-secret.yaml
 namespace: rhtap-build-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/quay-push-secret.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/quay-push-secret.yaml
@@ -1,0 +1,26 @@
+# Needed for build-service pipelines to push to quay.io/redhat-appstudio/build-service
+# Temporary, needed until build-service is onboarded to Konflux
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: quay-push-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/tekton-ci/quay-push-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quay-push-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"


### PR DESCRIPTION
STONEBLD-1937

We're onboarding build-service to Konflux, but build-service already has Tekton pipelines running in the tekton-ci namespace. Because of that, build-service cannot be onboarded to the rhtap-build-tenant namespace (see https://pipelinesascode.com/docs/guide/repositorycrd/ ):

* the Repository is already present in the tekton-ci namespace
* the Repository must only exist in one namespace
* the pipelines must run in the same namespace

To avoid losing CI completely for an extended period of time, we want to keep the old pipelines working while we slowly onboard to Konflux. That means we need to move the old pipelines from the tekton-ci namespace to the rhtap-build-tenant namespace.

To do that, we need to:

* delete Repo from tekton-ci (in redhat-appstudio/infra-deployments)
* add Repo to rhtap-build-tenant (Konflux will do that automatically)
* add quay-push-secret (for quay.io/redhat-appstudio/build-service)