### PR TITLE
rhtap-build: update build-service app name

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_build-service-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_build-service-release-to-quay-rhtap-ser.yaml
@@ -7,5 +7,5 @@ metadata:
   name: build-service-release-to-quay-rhtap-ser
   namespace: rhtap-build-tenant
 spec:
-  application: build
+  application: build-service
   target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-enterprise-contract.yaml
@@ -4,7 +4,7 @@ metadata:
   name: build-enterprise-contract
   namespace: rhtap-build-tenant
 spec:
-  application: build
+  application: build-service
   contexts:
   - description: Application testing
     name: application

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
@@ -4,7 +4,7 @@ metadata:
   name: build-enterprise-contract
   namespace: rhtap-build-tenant
 spec:
-  application: build
+  application: build-service
   contexts:
     - description: Application testing
       name: application

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
@@ -7,7 +7,7 @@ metadata:
     release.appstudio.openshift.io/auto-release: 'true'
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
-  application: build
+  application: build-service
   target: rhtap-releng-tenant
 ---
 apiVersion: appstudio.redhat.com/v1alpha1


### PR DESCRIPTION
STONEBLD-1987

Long ago, someone tried to onboard build-service to Konflux under the
'build' application. Now, we are finally re-onboarding for real.

Rename the application to 'build-service' to match the naming scheme
used for all the other Build team components.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
