### PR TITLE
Update trusted-artifacts application

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-trusted-artifacts-rpa.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_releaseplanadmission_rhtap-build-trusted-artifacts-rpa.yaml
@@ -7,14 +7,14 @@ metadata:
   namespace: rh-managed-rhtap-ser-tenant
 spec:
   applications:
-  - build-trusted-artifacts
+  - trusted-artifacts
   data:
     images:
       addGitShaTag: true
       defaultTag: latest
     mapping:
       components:
-      - name: build-trusted-artifacts
+      - name: trusted-artifacts
         repository: quay.io/redhat-appstudio/build-trusted-artifacts
     pyxis:
       secret: pyxis-production-secret

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_trusted-artifacts-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1alpha1_releaseplan_trusted-artifacts-to-quay-rhtap-ser.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     release.appstudio.openshift.io/auto-release: "true"
     release.appstudio.openshift.io/standing-attribution: "true"
-  name: build-trusted-artifacts-to-quay-rhtap-ser
+  name: trusted-artifacts-to-quay-rhtap-ser
   namespace: rhtap-build-tenant
 spec:
-  application: build-trusted-artifacts
+  application: trusted-artifacts
   target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_trusted-artifacts-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_trusted-artifacts-enterprise-contract.yaml
@@ -1,10 +1,10 @@
 apiVersion: appstudio.redhat.com/v1beta1
 kind: IntegrationTestScenario
 metadata:
-  name: build-trusted-artifacts-enterprise-contract
+  name: trusted-artifacts-enterprise-contract
   namespace: rhtap-build-tenant
 spec:
-  application: build-trusted-artifacts
+  application: trusted-artifacts
   contexts:
   - description: Application testing
     name: application

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- release_plan_admission-build-trusted-artifacts.yaml
+- release_plan_admission-trusted-artifacts.yaml
 - release-service-account-rb.yaml
 - ec-policy.yaml
 - persistent-volume-claim.yaml

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-trusted-artifacts.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/release_plan_admission-trusted-artifacts.yaml
@@ -8,14 +8,14 @@ metadata:
     release.appstudio.openshift.io/auto-release: 'true'
 spec:
   applications:
-    - build-trusted-artifacts
+    - trusted-artifacts
   data:
     images:
       addGitShaTag: true
       defaultTag: latest
     mapping:
       components:
-        - name: build-trusted-artifacts
+        - name: trusted-artifacts
           repository: "quay.io/redhat-appstudio/build-trusted-artifacts"
     pyxis:
       secret: pyxis-production-secret

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
@@ -47,10 +47,10 @@ spec:
 apiVersion: appstudio.redhat.com/v1beta1
 kind: IntegrationTestScenario
 metadata:
-  name: build-trusted-artifacts-enterprise-contract
+  name: trusted-artifacts-enterprise-contract
   namespace: rhtap-build-tenant
 spec:
-  application: build-trusted-artifacts
+  application: trusted-artifacts
   contexts:
     - description: Application testing
       name: application

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/release_plan.yaml
@@ -25,13 +25,13 @@ spec:
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
-  name: build-trusted-artifacts-to-quay-rhtap-ser
+  name: trusted-artifacts-to-quay-rhtap-ser
   namespace: rhtap-build-tenant
   labels:
     release.appstudio.openshift.io/auto-release: 'true'
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
-  application: build-trusted-artifacts
+  application: trusted-artifacts
   target: rhtap-releng-tenant
 ---
 apiVersion: appstudio.redhat.com/v1alpha1


### PR DESCRIPTION
The application `trusted-artifacts` was previously created with the name `build-trusted-artifacts`. However, once it was re-onboarded to Konflux, the new name was chosen.

This commit changes the relevant resources to use the new application name, with the matching new component name.