### PR TITLE
Add ReleasePlan for the maestro application in crt-redhat-acm

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_releaseplan_maestro.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_releaseplan_maestro.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: maestro
+  namespace: crt-redhat-acm-tenant
+spec:
+  application: maestro
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/release-plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/release-plan.yaml
@@ -20,3 +20,14 @@ metadata:
 spec:
   application: hypershift-operator-main-hotfix
   target: rhtap-releng-tenant
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: maestro
+spec:
+  application: maestro
+  target: rhtap-releng-tenant


### PR DESCRIPTION
## Summary of Changes

This PR adds a ReleasePlan for the Maestro application in the crt-redhat-acm workspace to reference the RPA created [here](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/commit/088c4fb26e17597c25e498dff1481340150f2e4a).  