### PR TITLE
feat: Add the integration test for running e2e-test

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_build-task-dockerfile-e2e-test.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_build-task-dockerfile-e2e-test.yaml
@@ -1,0 +1,19 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: build-task-dockerfile-e2e-test
+  namespace: rhtap-build-tenant
+spec:
+  application: build-tasks-dockerfiles
+  contexts:
+  - description: E2E testing
+    name: application
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-tasks-dockerfiles.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: integration-tests/pipelines/e2e-tests-pipeline.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
@@ -89,3 +89,23 @@ spec:
       - name: pathInRepo
         value: pipelines/enterprise-contract.yaml
     resolver: git
+---
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: build-task-dockerfile-e2e-test
+  namespace: rhtap-build-tenant
+spec:
+  application: build-tasks-dockerfiles
+  contexts:
+    - description: E2E testing
+      name: application
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/build-tasks-dockerfiles.git'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: integration-tests/pipelines/e2e-tests-pipeline.yaml
+    resolver: git


### PR DESCRIPTION
This PR adds the integration test for running the e2e-tests in the rhtap-build-tenant ns.
Part of the story: https://issues.redhat.com/browse/STONEBLD-2353