### PR TITLE
Update build-definitions references to new org

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/awood1-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhsm-subscriptions-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_hypershift-operator-main-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_hypershift-operator-main-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_notifications-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_notifications-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_cloud-connector-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_cloud-connector-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_export-service-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_export-service-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-sc-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_insights-ingress-go-sc-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_playbook-dispatcher-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_playbook-dispatcher-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_storage-broker-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_storage-broker-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_runtimes-inventory-operator-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_runtimes-inventory-operator-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_enterprise-contract.yaml
@@ -13,7 +13,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_fbc-v4-16-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_fbc-v4-16-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_multiarch-tuning-operator-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_multiarch-tuning-operator-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-acs-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_acs-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-acs-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_acs-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-trex-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-trex-tenant-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-trex-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-trex-tenant-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-11-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-11-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-12-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-12-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-13-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-13-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-14-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-14-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-15-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhbk-fbc-v4-15-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-service-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_build-service-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_image-controller-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_image-controller-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-syft-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rh-syft-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_trusted-artifacts-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_trusted-artifacts-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_external-secrets-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_external-secrets-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_application-service-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_application-service-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_integration-service-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_integration-service-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_oras-container-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_oras-container-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhtap-consoledot-frontend-build-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_rhtap-consoledot-frontend-build-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_o11y-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_o11y-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_project-controller-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_project-controller-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_segment-bridge-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_segment-bridge-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tools-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_tools-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_workspace-manager-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_workspace-manager-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_internal-services-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_internal-services-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_release-service-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_release-service-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_remotesecret-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_remotesecret-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_spi-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_spi-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/sfo-security-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_sfo-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/sfo-security-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_sfo-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ecosystem-images-enterprise-contract-git-init.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ecosystem-images-enterprise-contract-git-init.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/auto-generated/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ecosystem-images-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_ecosystem-images-enterprise-contract.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/awood1-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/awood1-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/hypershift-operator-main/enterprise-contract.integrationtestscenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/hypershift-operator-main/enterprise-contract.integrationtestscenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/notifications-enterprise-contract_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/notifications-enterprise-contract_integration_test.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/redhat-appstudio/build-definitions
+      value: https://github.com/konflux-ci/build-definitions
     - name: revision
       value: main
     - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/cloud_connector_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/cloud_connector_integration_test.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/export_service_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/export_service_integration_test.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/ingress_sc_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/ingress_sc_integration_test.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/playbook_dispatcher_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/playbook_dispatcher_integration_test.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/storage_broker_integration_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/storage_broker_integration_test.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/konflux-infra-tenant/integration_test_scenario.yaml
@@ -12,7 +12,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_patches/integrationtestscenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_patches/integrationtestscenario.yaml
@@ -10,7 +10,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: https://github.com/redhat-appstudio/build-definitions
+        value: https://github.com/konflux-ci/build-definitions
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rh-acs-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-acs-tenant/integration_test_scenario.yaml
@@ -11,7 +11,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-subs-watch-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rh-trex-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-trex-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/rhbk-fbc-enterprise-contract.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhbk-release-tenant/rhbk-fbc-enterprise-contract.yaml
@@ -12,7 +12,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -35,7 +35,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -58,7 +58,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -81,7 +81,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -104,7 +104,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -37,7 +37,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -60,7 +60,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -83,7 +83,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-gitops-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-has-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-integration-tenant/integration_test_scenario.yaml
@@ -15,7 +15,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -38,7 +38,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/integration_test_scenario_consoledot_frontend.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/integration_test_scenario_consoledot_frontend.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-o11y-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -37,7 +37,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -60,7 +60,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -83,7 +83,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -106,7 +106,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -37,7 +37,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-spi-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo
@@ -37,7 +37,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/sfo-security-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/sfo-security-tenant/integration_test_scenario.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/integration_test_scenario_ecosystem.yaml
+++ b/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/integration_test_scenario_ecosystem.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/integration_test_scenario_ecosystem_git_init.yaml
+++ b/cluster/stone-prd-rh01/tenants/tekton-ecosystem-tenant/integration_test_scenario_ecosystem_git_init.yaml
@@ -14,7 +14,7 @@ spec:
   resolverRef:
     params:
       - name: url
-        value: 'https://github.com/redhat-appstudio/build-definitions'
+        value: 'https://github.com/konflux-ci/build-definitions'
       - name: revision
         value: main
       - name: pathInRepo


### PR DESCRIPTION
STONEBLD-2339

The build-definitions repo has moved from github.com/redhat-appstudio to
github.com/konflux-ci. Update references accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
