### PR TITLE
Modified sfo-security to reflect the correct application naming

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/sfo-security-tenant/appstudio.redhat.com_v1alpha1_releaseplan_sfo-release-as-service.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/sfo-security-tenant/appstudio.redhat.com_v1alpha1_releaseplan_sfo-release-as-service.yaml
@@ -7,5 +7,5 @@ metadata:
   name: sfo-release-as-service
   namespace: sfo-security-tenant
 spec:
-  application: sfo
+  application: splunk-forwarder-operator
   target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/sfo-security-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_sfo-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/sfo-security-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_sfo-enterprise-contract.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sfo-enterprise-contract
   namespace: sfo-security-tenant
 spec:
-  application: sfo
+  application: splunk-forwarder-operator
   contexts:
   - description: Application testing
     name: application

--- a/cluster/stone-prd-rh01/tenants/sfo-security-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/sfo-security-tenant/integration_test_scenario.yaml
@@ -7,7 +7,7 @@ spec:
   params: 
     - name: POLICY_CONFIGURATION
       value: enterprise-contract-service/app-interface-standard
-  application: sfo
+  application: splunk-forwarder-operator
   contexts:
     - description: Application testing
       name: application

--- a/cluster/stone-prd-rh01/tenants/sfo-security-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/sfo-security-tenant/release_plan.yaml
@@ -7,5 +7,5 @@ metadata:
     release.appstudio.openshift.io/auto-release: 'true'
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
-  application: sfo
+  application: splunk-forwarder-operator
   target: rhtap-releng-tenant


### PR DESCRIPTION
Fixing the naming of application field to reflect proper name of application splunk-forwarder-operator