### PR TITLE
Adding bonfire-tekton integration test to hcc-accessmanagement-tenant

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-accessmanagement-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_platform-feedback-bonfire-tekton.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-accessmanagement-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_platform-feedback-bonfire-tekton.yaml
@@ -1,0 +1,23 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "true"
+  name: platform-feedback-bonfire-tekton
+  namespace: hcc-accessmanagement-tenant
+spec:
+  application: platform-feedback
+  params:
+  - name: APP_NAME
+    value: platform-feedback
+  - name: COMPONENT_NAME
+    value: platform-feedback
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/RedHatInsigths/bonfire-tekton.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/basic.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/hcc-accessmanagement-tenant/integration_test_tekton.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-accessmanagement-tenant/integration_test_tekton.yaml
@@ -1,0 +1,23 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "true" # Change to "true" if you don't need the test to be mandatory
+  name: platform-feedback-bonfire-tekton
+  namespace: hcc-accessmanagement-tenant
+spec:
+  application: platform-feedback
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/RedHatInsigths/bonfire-tekton.git
+    - name: revision
+      value: main # Or whatever branch you want to test
+    - name: pathInRepo
+      value: pipelines/basic.yaml # This is the path to the pipeline
+    resolver: git
+  params:
+    - name: APP_NAME
+      value: platform-feedback
+    - name: COMPONENT_NAME
+      value: platform-feedback

--- a/cluster/stone-prd-rh01/tenants/hcc-accessmanagement-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-accessmanagement-tenant/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - integration_test_scenario.yaml
+- integration_test_tekton.yaml
 
 namespace: hcc-accessmanagement-tenant


### PR DESCRIPTION
Adding bonfire-tekton integration test to hcc-accessmanagement-tenant for application and component: platform-feedback. 

