### PR TITLE
Add releaseGracePeriodDays to HCC Notifications release plan

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/appstudio.redhat.com_v1alpha1_releaseplan_notifications-release-as-ms.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/appstudio.redhat.com_v1alpha1_releaseplan_notifications-release-as-ms.yaml
@@ -8,4 +8,5 @@ metadata:
   namespace: hcc-notifications-tenant
 spec:
   application: notifications
+  releaseGracePeriodDays: 2
   target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/notifications_release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-notifications-tenant/notifications_release_plan.yaml
@@ -9,3 +9,5 @@ metadata:
 spec:
   application: notifications
   target: rhtap-releng-tenant
+  # Lowers the delay before the release CR garbage collector can delete release snapshots.
+  releaseGracePeriodDays: 2


### PR DESCRIPTION
HCC Notifications is creating lots of releases (sometimes more than 100 a day) so we need the release CR garbage collector to delete release snapshots more aggressively so that we don't hit the snapshots quota in Konflux.