### PR TITLE
Modify cloud-connector to use a custom version of the bonfire cicd scripts

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_cloud-connector-tekton-insights.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_cloud-connector-tekton-insights.yaml
@@ -23,6 +23,10 @@ spec:
     value: not e2e
   - name: IQE_CJI_TIMEOUT
     value: 30m
+  - name: URL
+    value: https://github.com/dehort/cicd-tools
+  - name: REVISION
+    value: change_component_name_to_clowd_app_name_for_deploy_iqe_cji
   resolverRef:
     params:
     - name: url

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/cloud_connector_tekton_test.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/cloud_connector_tekton_test.yaml
@@ -32,3 +32,7 @@ spec:
         value: not e2e
       - name: IQE_CJI_TIMEOUT
         value: 30m
+      - name: URL
+        value: https://github.com/dehort/cicd-tools
+      - name: REVISION
+        value: change_component_name_to_clowd_app_name_for_deploy_iqe_cji


### PR DESCRIPTION
I want to configure cloud-connector to use a custom set of cicd scripts which are located here:  https://github.com/dehort/cicd-tools 
on branch: change_component_name_to_clowd_app_name_for_deploy_iqe_cji

Will this do that?