### PR TITLE
Add integration test scenarios for orchestrator-helm-operator

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_orchestrator-helm-operator-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_orchestrator-helm-operator-enterprise-contract.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: orchestrator-helm-operator-enterprise-contract
+  namespace: orchestrator-releng-tenant
+spec:
+  application: orchestrator-helm-operator
+  contexts:
+  - description: Application testing
+    name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/tmp-onboard-policy
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/konflux-ci/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/integration_test_scenario.yaml
@@ -1,0 +1,21 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: orchestrator-helm-operator-enterprise-contract
+spec:
+  params:
+    - name: POLICY_CONFIGURATION
+      value: rhtap-releng-tenant/tmp-onboard-policy
+  application: orchestrator-helm-operator
+  contexts:
+    - description: Application testing
+      name: application
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/konflux-ci/build-definitions'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - release-plan.yaml
+  - integration_test_scenario.yaml


### PR DESCRIPTION
Adds the integration tests for enterprise contract validation as described in the onboarding documentation.