### PR TITLE
Migrate build-definitions redhat-appstudio images

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -22,7 +22,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Release Policies
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-policy.yaml
@@ -17,7 +17,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy-cnv.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy-cnv.yaml
@@ -18,7 +18,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-fbc-stage-index-policy.yaml
@@ -18,7 +18,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_app-interface-standard.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_app-interface-standard.yaml
@@ -19,7 +19,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Release Policies
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -17,7 +17,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -14,7 +14,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Default
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy-o11y.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy-o11y.yaml
@@ -18,7 +18,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Release Policies
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_rh-policy.yaml
@@ -16,7 +16,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Release Policies
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_consoledot-frontend-standard.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/appstudio.redhat.com_v1alpha1_enterprisecontractpolicy_consoledot-frontend-standard.yaml
@@ -22,7 +22,7 @@ spec:
   sources:
   - data:
     - github.com/release-engineering/rhtap-ec-policy//data
-    - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+    - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
     name: Release Policies
     policy:
     - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-bifrost-tenant/ec-policy.yaml
@@ -28,7 +28,7 @@ spec:
     - name: Release Policies
       data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       policy:
         - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5
       ruleData:

--- a/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-cnv-fbc-tenant/ec-policy.yaml
@@ -17,7 +17,7 @@ spec:
   sources:
     - data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5
@@ -42,7 +42,7 @@ spec:
   sources:
     - data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5
@@ -67,7 +67,7 @@ spec:
   sources:
     - data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       name: Default
       ruleData:
         allowed_registry_prefixes:

--- a/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-mng-s-2-tenant/ec-policy.yaml
@@ -16,7 +16,7 @@ spec:
   sources:
     - data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5
@@ -48,6 +48,6 @@ spec:
     - name: Release Policies
       data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       policy:
         - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-red-hat-acm-tenant/ec-policy.yaml
@@ -13,7 +13,7 @@ spec:
   sources:
     - data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       name: Default
       policy:
       - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy-o11y.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy-o11y.yaml
@@ -24,6 +24,6 @@ spec:
     - name: Release Policies
       data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       policy:
         - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy.yaml
+++ b/cluster/stone-prd-rh01/managed/rh-managed-rhtap-ser-tenant/ec-policy.yaml
@@ -18,6 +18,6 @@ spec:
     - name: Release Policies
       data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       policy:
         - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5

--- a/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/consoledot-frontend-standard-policy.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-migration-tenant/consoledot-frontend-standard-policy.yaml
@@ -25,6 +25,6 @@ spec:
     - name: Release Policies
       data:
         - github.com/release-engineering/rhtap-ec-policy//data
-        - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       policy:
         - oci::quay.io/enterprise-contract/ec-release-policy:git-5ecd517@sha256:e4947f3c658bf34ac9b66e91e8bdcf3ab52fd634d95949d958829edfee24e4e5


### PR DESCRIPTION
STONEBLD-2339

All the images built in build-definitions CI now get released to the
quay.io/konflux-ci organization.

Replace the relevant redhat-appstudio[-tekton-catalog] references in
this repo with konflux-ci[/tekton-catalog] references.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
