### PR TITLE
Add EnterpriseContract ITS for Maestro

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_maestro-main-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_maestro-main-enterprise-contract.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: maestro-main-enterprise-contract
+  namespace: crt-redhat-acm-tenant
+spec:
+  application: maestro-main
+  contexts:
+  - description: Application testing
+    name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/app-interface-standard
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/konflux-ci/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - release-plan.yaml
+  - maestro.enterprise-contract.integrationtestscenario.yaml
   - maestro/overlay/maestro/main/
   - hypershift-operator-main/
 namespace: crt-redhat-acm-tenant

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro.enterprise-contract.integrationtestscenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/maestro.enterprise-contract.integrationtestscenario.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: maestro-main-enterprise-contract
+  namespace: crt-redhat-acm-tenant
+spec:
+  application: maestro-main
+  contexts:
+  - description: Application testing
+    name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/app-interface-standard
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/konflux-ci/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract.yaml
+    resolver: git


### PR DESCRIPTION
## Summary of Changes

This PR adds an IntegrationTestScenario for the Maestro on-prem deliverable.  We haven't determined which on-prem gate to use yet, so we'll use this services-standard policy to match the current gate in the RPA.  