### PR TITLE
Correct Insights spelling. 

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-hms-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_provisioning-frontend-bonfire-tekton.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-hms-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_provisioning-frontend-bonfire-tekton.yaml
@@ -31,7 +31,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/RedHatInsigths/bonfire-tekton.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo

--- a/cluster/stone-prd-rh01/tenants/rh-hms-tenant/provisioning-frontend-integration.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-hms-tenant/provisioning-frontend-integration.yaml
@@ -10,7 +10,7 @@ spec:
   resolverRef:
     params:
     - name: url
-      value: https://github.com/RedHatInsigths/bonfire-tekton.git
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
     - name: revision
       value: main
     - name: pathInRepo


### PR DESCRIPTION
Adding the fix: https://github.com/RedHatInsights/bonfire-tekton/commit/c30f877c2492568fc95d4d43e5c6d5bf2fabf65f 