### PR TITLE
[orchestrator-releng] Update component name references to helm-operator

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1alpha1_releaseplan_helm-operator.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1alpha1_releaseplan_helm-operator.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     release.appstudio.openshift.io/auto-release: "true"
     release.appstudio.openshift.io/standing-attribution: "true"
-  name: orchestrator-helm-operator
+  name: helm-operator
   namespace: orchestrator-releng-tenant
 spec:
-  application: orchestrator-helm-operator
+  application: helm-operator
   target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_helm-operator-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_helm-operator-enterprise-contract.yaml
@@ -1,10 +1,10 @@
 apiVersion: appstudio.redhat.com/v1beta1
 kind: IntegrationTestScenario
 metadata:
-  name: orchestrator-helm-operator-enterprise-contract
+  name: helm-operator-enterprise-contract
   namespace: orchestrator-releng-tenant
 spec:
-  application: orchestrator-helm-operator
+  application: helm-operator
   contexts:
   - description: Application testing
     name: application

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/integration_test_scenario.yaml
@@ -1,13 +1,13 @@
 apiVersion: appstudio.redhat.com/v1beta1
 kind: IntegrationTestScenario
 metadata:
-  name: orchestrator-helm-operator-enterprise-contract
+  name: helm-operator-enterprise-contract
   namespace: orchestrator-releng-tenant
 spec:
   params:
     - name: POLICY_CONFIGURATION
       value: rhtap-releng-tenant/fbc-stage
-  application: orchestrator-helm-operator
+  application: helm-operator
   contexts:
     - description: Application testing
       name: application

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/release-plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/release-plan.yaml
@@ -2,10 +2,10 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
-  name: orchestrator-helm-operator
+  name: helm-operator
   labels:
     release.appstudio.openshift.io/auto-release: 'true'
     release.appstudio.openshift.io/standing-attribution: 'true'
 spec:
-  application: orchestrator-helm-operator
+  application: helm-operator
   target: rhtap-releng-tenant


### PR DESCRIPTION
Remove prefix `orchestrator` from `ReleasePlan` and `IntegrationTestScenario` manifests to align with renamed component.

@ralphbean @rgolangh PTAL.