### PR TITLE
Update policy names as per CLOUDDST-22158

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_hypershift-operator-main-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_hypershift-operator-main-enterprise-contract.yaml
@@ -10,7 +10,7 @@ spec:
     name: application
   params:
   - name: POLICY_CONFIGURATION
-    value: rhtap-releng-tenant/app-interface-hypershift
+    value: rhtap-releng-tenant/app-interface-crt-redhat-acm
   resolverRef:
     params:
     - name: url

--- a/auto-generated/cluster/stone-prd-rh01/tenants/rh-acs-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_acs-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rh-acs-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_acs-enterprise-contract.yaml
@@ -10,7 +10,7 @@ spec:
     name: application
   params:
   - name: POLICY_CONFIGURATION
-    value: rhtap-releng-tenant/registry-rhacs
+    value: rhtap-releng-tenant/registry-rh-acs
   resolverRef:
     params:
     - name: url

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/hypershift-operator-main/enterprise-contract.integrationtestscenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/hypershift-operator-main/enterprise-contract.integrationtestscenario.yaml
@@ -10,7 +10,7 @@ spec:
       name: application
   params:
     - name: POLICY_CONFIGURATION
-      value: rhtap-releng-tenant/app-interface-hypershift
+      value: rhtap-releng-tenant/app-interface-crt-redhat-acm
   resolverRef:
     params:
       - name: url

--- a/cluster/stone-prd-rh01/tenants/rh-acs-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/rh-acs-tenant/integration_test_scenario.yaml
@@ -19,4 +19,4 @@ spec:
     resolver: git
   params:
   - name: POLICY_CONFIGURATION
-    value: rhtap-releng-tenant/registry-rhacs
+    value: rhtap-releng-tenant/registry-rh-acs


### PR DESCRIPTION
Here from this comment - https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/521#note_11100967 

Out of all the policy name changes in https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/521
```
registry-rhacs -> registry-rh-acs  # Updated in this MR
app-interface-hypershift -> app-interface-crt-redhat-acm  # Updated in this MR
registry-rhtpa -> registry-trusted-content  # Not found in the repo
app-interface-clio-wrklds -> app-interface-clio-wrklds-pipeline  # Not found in the repo
```

This MR reflects changes to the names that I found in this repo. 

cc - @ralphbean 