### PR TITLE
Add acrobot-slack-tenant

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/acrobot-slack-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_acrobot-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/acrobot-slack-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_acrobot-enterprise-contract.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: acrobot-enterprise-contract
+  namespace: acrobot-slack-tenant
+spec:
+  application: acrobot
+  contexts:
+  - description: Application testing
+    name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/tmp-onboard-policy
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/acrobot-slack-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/acrobot-slack-tenant/integration_test_scenario.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: acrobot-enterprise-contract
+  namespace: acrobot-slack-tenant
+spec:
+  params:
+    - name: POLICY_CONFIGURATION
+      value: rhtap-releng-tenant/tmp-onboard-policy
+  application: acrobot
+  contexts:
+    - description: Application testing
+      name: application
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/build-definitions'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/acrobot-slack-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/acrobot-slack-tenant/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- integration_test_scenario.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
Hi! I'm doing my best to follow the Red Hat [guide](https://docs.google.com/document/d/1bKE4pmrufEb1QROo7XhMVEmUClc--WtAmX1__rxNscc/edit) for adding a new application in order to host the Slack version of Acrobot.

I apologize if I'm doing this wrong or if this is in the wrong place.