### PR TITLE
osde2e-cicada: add tmp EC

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_osde2e-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_osde2e-enterprise-contract.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: osde2e-enterprise-contract
+  namespace: osde2e-cicada-tenant
+spec:
+  application: osde2e
+  contexts:
+  - description: Application testing
+    name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/tmp-onboard-policy
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/integration_test_scenario.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: osde2e-enterprise-contract
+  namespace: osde2e-cicada-tenant
+spec:
+  params:
+    - name: POLICY_CONFIGURATION
+      value: rhtap-releng-tenant/tmp-onboard-policy
+  application: osde2e
+  contexts:
+    - description: Application testing
+      name: application
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/build-definitions'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/kustomization.yaml
@@ -1,3 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+- integration_test_scenario.yaml


### PR DESCRIPTION
add back the EC with POLICY_CONFIGURATION set to tmp-onboard-policy

Signed-off-by: Brady Pratt <bpratt@redhat.com>
