### PR TITLE
Add siteconfig ReleasePlan

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_releaseplan_siteconfig.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/appstudio.redhat.com_v1alpha1_releaseplan_siteconfig.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: siteconfig
+  namespace: crt-redhat-acm-tenant
+spec:
+  application: siteconfig-main
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/release-plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/crt-redhat-acm-tenant/release-plan.yaml
@@ -31,3 +31,14 @@ metadata:
 spec:
   application: maestro-main
   target: rhtap-releng-tenant
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: siteconfig
+spec:
+  application: siteconfig-main
+  target: rhtap-releng-tenant


### PR DESCRIPTION
## Summary

This PR adds a ReleasePlan for SiteConfig now that https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/671 is merged to add it to our RPA