### PR TITLE
[orchestrator-releng] Add FBC ReleasePlan manifests for OCP 4.14

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1alpha1_releaseplan_fbc-v4-14-release-as-production-fbc.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1alpha1_releaseplan_fbc-v4-14-release-as-production-fbc.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "false"
+    release.appstudio.openshift.io/releasePlanAdmission: operator-fbc-prod-index
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: fbc-v4-14-release-as-production-fbc
+  namespace: orchestrator-releng-tenant
+spec:
+  application: fbc-v4-14
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1alpha1_releaseplan_fbc-v4-14-release-as-staging-fbc.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1alpha1_releaseplan_fbc-v4-14-release-as-staging-fbc.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/releasePlanAdmission: operator-fbc-staging-index
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: fbc-v4-14-release-as-staging-fbc
+  namespace: orchestrator-releng-tenant
+spec:
+  application: fbc-v4-14
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_fbc-v4-14-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_fbc-v4-14-enterprise-contract.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: fbc-v4-14-enterprise-contract
+  namespace: orchestrator-releng-tenant
+spec:
+  application: fbc-v4-14
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/fbc-stage

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/integrationtestscenarios/enterprise-contract/integrationtestscenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/integrationtestscenarios/enterprise-contract/integrationtestscenario.yaml
@@ -1,0 +1,9 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  name: fbc-v4-14-enterprise-contract
+spec:
+  application: fbc-v4-14
+  params:
+    - name: POLICY_CONFIGURATION
+      value: rhtap-releng-tenant/fbc-stage

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/integrationtestscenarios/enterprise-contract/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/integrationtestscenarios/enterprise-contract/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - integrationtestscenario.yaml

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/kustomization.yaml
@@ -1,0 +1,7 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+# Naming: <API_GROUP>/<KIND_PLURAL>/<METADATA_NAME>
+resources:
+  - integrationtestscenarios/enterprise-contract
+  - releaseplans/production
+  - releaseplans/staging

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/releaseplans/production/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/releaseplans/production/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - releaseplan.yaml

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/releaseplans/production/releaseplan.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/releaseplans/production/releaseplan.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: fbc-v4-14-release-as-production-fbc
+  namespace: orchestrator-releng-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'false'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+    release.appstudio.openshift.io/releasePlanAdmission: operator-fbc-prod-index
+spec:
+  application: fbc-v4-14
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/releaseplans/staging/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/releaseplans/staging/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - releaseplan.yaml

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/releaseplans/staging/releaseplan.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/fbc-v4-14/releaseplans/staging/releaseplan.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: fbc-v4-14-release-as-staging-fbc
+  namespace: orchestrator-releng-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+    release.appstudio.openshift.io/releasePlanAdmission: operator-fbc-staging-index
+spec:
+  application: fbc-v4-14
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/kustomization.yaml
@@ -7,3 +7,4 @@ namespace: orchestrator-releng-tenant
 resources:
   - operator
   - serverless-workflows
+  - fbc-v4-14


### PR DESCRIPTION
Adds the ReleasePlans manifests for the Orchestrator Operator