### PR TITLE
Rename clio application name to cli-manager-operator

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/clio-wrklds-pipeline-tenant/appstudio.redhat.com_v1alpha1_releaseplan_cli-manager-operator.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/clio-wrklds-pipeline-tenant/appstudio.redhat.com_v1alpha1_releaseplan_cli-manager-operator.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     release.appstudio.openshift.io/auto-release: "true"
     release.appstudio.openshift.io/standing-attribution: "true"
-  name: clio-wrklds-pipeline-prod
+  name: cli-manager-operator
   namespace: clio-wrklds-pipeline-tenant
 spec:
-  application: clio-wrklds-pipeline-prod
+  application: cli-manager-operator
   target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/clio-wrklds-pipeline-tenant/release-plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/clio-wrklds-pipeline-tenant/release-plan.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     release.appstudio.openshift.io/auto-release: 'true'
     release.appstudio.openshift.io/standing-attribution: 'true'
-  name: clio-wrklds-pipeline-prod
+  name: cli-manager-operator
   namespace: clio-wrklds-pipeline-tenant
 spec:
-  application: clio-wrklds-pipeline-prod
+  application: cli-manager-operator
   target: rhtap-releng-tenant


### PR DESCRIPTION
This PR renames the application name in cli manager release plan to `cli-manager-operator`.