### PR TITLE
Fix Pulp not running with the PR for basic_no_iqe.yaml

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/pulp-services-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_pulp-bonfire-tekton.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/pulp-services-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_pulp-bonfire-tekton.yaml
@@ -18,6 +18,8 @@ spec:
     value: null
   - name: COMPONENT_NAME
     value: pulp
+  - name: IQE_PLUGINS
+    value: ""
   - name: EXTRA_DEPLOY_ARGS
     value: --set-parameter pulp/PULP_API_MEMORY_LIMIT=4096Mi --set-parameter pulp/PULP_API_MEMORY_REQUEST=2048Mi
       provisioning sources image-builder-crc

--- a/cluster/stone-prd-rh01/tenants/pulp-services-tenant/pulp-bonfire-tekton.yaml
+++ b/cluster/stone-prd-rh01/tenants/pulp-services-tenant/pulp-bonfire-tekton.yaml
@@ -28,5 +28,7 @@ spec:
       value: # Name of app-sre "resourceTemplate" in deploy.yaml for this component. If it is the same as the name in Konflux, you don't need to fill this
     - name: COMPONENT_NAME
       value: "pulp"
+    - name: IQE_PLUGINS
+      value: "" # Dummy value to pass the WIP PR for basic_no_iqe.yaml
     - name: EXTRA_DEPLOY_ARGS # This wasn't in the documentation, but in the bonfire-tekton code
       value: "--set-parameter pulp/PULP_API_MEMORY_LIMIT=4096Mi --set-parameter pulp/PULP_API_MEMORY_REQUEST=2048Mi provisioning sources image-builder-crc"


### PR DESCRIPTION
Otherwise I get:
```
[User error] PipelineRun pulp-services-tenant parameters is missing some parameters required by Pipeline pulp-c8v4d-22nnb's parameters: pipelineRun missing parameters: [IQE_PLUGINS]
```

We're using this PR, and I got the go ahead to use it: https://github.com/RedHatInsights/bonfire-tekton/pull/35

PULP-110