### PR TITLE
SDCICD-1329: temporarly drop POLICY_CONFIGURATION

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/oeo-cicada-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_oeo-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/oeo-cicada-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_oeo-enterprise-contract.yaml
@@ -8,9 +8,7 @@ spec:
   contexts:
   - description: Application testing
     name: application
-  params:
-  - name: POLICY_CONFIGURATION
-    value: rhtap-releng-tenant/app-interface-standard
+  params: []
   resolverRef:
     params:
     - name: url

--- a/cluster/stone-prd-rh01/tenants/oeo-cicada-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/oeo-cicada-tenant/integration_test_scenario.yaml
@@ -4,9 +4,7 @@ metadata:
   name: oeo-enterprise-contract
   namespace: oeo-cicada-tenant
 spec:
-  params:
-    - name: POLICY_CONFIGURATION
-      value: rhtap-releng-tenant/app-interface-standard
+  params: []
   application: osd-example-operator
   contexts:
     - description: Application testing


### PR DESCRIPTION
bundle images are not passing preflight checks, this is causing the ECP
to fail and block development. This should be added back once the issue
with the preflight check is resolved

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1719559548542999?thread_ts=1719475396.888239&cid=C04PZ7H0VA8

Signed-off-by: Brady Pratt <bpratt@redhat.com>
