### PR TITLE
bootc-c9s application

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/appstudio.redhat.com_v1alpha1_application_bootc-c9s.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/appstudio.redhat.com_v1alpha1_application_bootc-c9s.yaml
@@ -1,0 +1,7 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: bootc-c9s
+  namespace: centos-bootc-tenant
+spec:
+  displayName: bootc-c9s

--- a/auto-generated/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/appstudio.redhat.com_v1alpha1_component_bootc-image-builder-c9s.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/appstudio.redhat.com_v1alpha1_component_bootc-image-builder-c9s.yaml
@@ -1,0 +1,18 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+  name: bootc-image-builder-c9s
+  namespace: centos-bootc-tenant
+spec:
+  application: bootc-c9s
+  componentName: bootc-image-builder-c9s
+  skipGitOpsResourceGeneration: true
+  source:
+    git:
+      context: ./
+      dockerfileUrl: Containerfile
+      revision: main
+      url: https://gitlab.com/redhat/rhel/bifrost/bootc-image-builder.git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/appstudio.redhat.com_v1alpha1_component_centos-bootc-c9s.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/appstudio.redhat.com_v1alpha1_component_centos-bootc-c9s.yaml
@@ -1,0 +1,18 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+  name: centos-bootc-c9s
+  namespace: centos-bootc-tenant
+spec:
+  application: bootc-c9s
+  componentName: centos-bootc-c9s
+  skipGitOpsResourceGeneration: true
+  source:
+    git:
+      context: ./
+      dockerfileUrl: Containerfile
+      revision: main
+      url: https://gitlab.com/redhat/centos-stream/containers/bootc.git

--- a/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/bootc-c9s.yaml
+++ b/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/bootc-c9s.yaml
@@ -1,0 +1,45 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: bootc-c9s
+  namespace: centos-bootc-tenant
+spec:
+  displayName: bootc-c9s
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+  name: bootc-image-builder-c9s
+  namespace: centos-bootc-tenant
+spec:
+  application: bootc-c9s
+  componentName: bootc-image-builder-c9s
+  skipGitOpsResourceGeneration: true
+  source:
+    git:
+      context: ./
+      dockerfileUrl: Containerfile
+      revision: main
+      url: https://gitlab.com/redhat/rhel/bifrost/bootc-image-builder.git
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/request: configure-pac
+    image.redhat.com/generate: '{"visibility": "public"}'
+  name: centos-bootc-c9s
+  namespace: centos-bootc-tenant
+spec:
+  application: bootc-c9s
+  componentName: centos-bootc-c9s
+  skipGitOpsResourceGeneration: true
+  source:
+    git:
+      context: ./
+      dockerfileUrl: Containerfile
+      revision: main
+      url: https://gitlab.com/redhat/centos-stream/containers/bootc.git

--- a/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/centos-bootc-tenant/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - release-plan.yaml
+  - bootc-c9s.yaml
 namespace: centos-bootc-tenant


### PR DESCRIPTION
centos-c9s application with two components:
- centos-bootc-c9s
- bootc-image-builder-c9s

This application will replace two applications:
- centos-bootc-c9s
- bootc-image-builder (which disappeared recently from the cluster)