### PR TITLE
Add ReleasePlan for runtimes-inventory-operator

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/appstudio.redhat.com_v1alpha1_releaseplan_runtimes-inventory-operator-release-as-product.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/appstudio.redhat.com_v1alpha1_releaseplan_runtimes-inventory-operator-release-as-product.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "false"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: runtimes-inventory-operator-release-as-product
+  namespace: insights-runtimes-tenant
+spec:
+  application: runtimes-inventory-operator
+  target: rhtap-releng-tenant

--- a/auto-generated/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_runtimes-inventory-operator-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_runtimes-inventory-operator-enterprise-contract.yaml
@@ -10,7 +10,7 @@ spec:
     name: application
   params:
   - name: POLICY_CONFIGURATION
-    value: rhtap-releng-tenant/tmp-onboard-policy
+    value: rhtap-releng-tenant/registry-standard
   resolverRef:
     params:
     - name: url

--- a/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/integration_test_scenario.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   params: 
     - name: POLICY_CONFIGURATION
-      value: rhtap-releng-tenant/tmp-onboard-policy
+      value: rhtap-releng-tenant/registry-standard
   application: runtimes-inventory-operator
   contexts:
     - description: Application testing

--- a/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - integration_test_scenario.yaml
+- release_plan.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/insights-runtimes-tenant/release_plan.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: runtimes-inventory-operator-release-as-product
+  namespace: insights-runtimes-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'false'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  application: runtimes-inventory-operator
+  target: rhtap-releng-tenant


### PR DESCRIPTION
This PR adds a ReleasePlan for runtimes-inventory-operator, and changes the policy in our IntegrationTestScenario.