### PR TITLE
rhtap-build: use shared Snyk token

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets.io_v1beta1_externalsecret_snyk-secret.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets.io_v1beta1_externalsecret_snyk-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: snyk-secret
+  namespace: rhtap-build-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: production/build/tekton-ci/snyk-shared-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: snyk-secret

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
 - infra-deployments-pr-creator.yaml
 - registry-redhat-io-pull-secret.yaml
+- snyk-secret.yaml
 namespace: rhtap-build-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/snyk-secret.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-build-tenant/external-secrets/snyk-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: snyk-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/tekton-ci/snyk-shared-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: snyk-secret


### PR DESCRIPTION
Currently, the rhtap-build workspace uses a personal Snyk API token. Switch to the same token used in the tekton-ci namespace - a service account token for the developer-red-hat-trusted-application-pipeline organization.

This is to:
* avoid the warning about approaching the monthly limit of 100 tests
* allow rhtap-build pipelines to upload results to the organization