### PR TITLE
SDCICD-1306: onboard entire configuration

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/appstudio.redhat.com_v1alpha1_application_osde2e.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/appstudio.redhat.com_v1alpha1_application_osde2e.yaml
@@ -1,0 +1,9 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: osde2e
+  namespace: osde2e-cicada-tenant
+spec:
+  description: |
+    A comprehensive test framework used for Service Delivery to test all aspects of Managed OpenShift Clusters
+  displayName: osde2e

--- a/auto-generated/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/appstudio.redhat.com_v1alpha1_component_osde2e-main.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/appstudio.redhat.com_v1alpha1_component_osde2e-main.yaml
@@ -1,0 +1,16 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build","bundle":"latest"}'
+    build.appstudio.openshift.io/request: configure-pac
+  name: osde2e-main
+  namespace: osde2e-cicada-tenant
+spec:
+  application: osde2e
+  componentName: osde2e-main
+  source:
+    git:
+      dockerfileUrl: Dockerfile.osde2e
+      revision: main
+      url: https://github.com/openshift/osde2e

--- a/auto-generated/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/appstudio.redhat.com_v1alpha1_imagerepository_imagerepository-for-osde2e-osde2e-main.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/appstudio.redhat.com_v1alpha1_imagerepository_imagerepository-for-osde2e-osde2e-main.yaml
@@ -1,0 +1,14 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ImageRepository
+metadata:
+  annotations:
+    image-controller.appstudio.redhat.com/update-component-image: "true"
+  labels:
+    appstudio.redhat.com/application: osde2e
+    appstudio.redhat.com/component: osde2e-main
+  name: imagerepository-for-osde2e-osde2e-main
+  namespace: osde2e-cicada-tenant
+spec:
+  image:
+    name: osde2e/osde2e-main
+    visibility: public

--- a/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/application.yaml
+++ b/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/application.yaml
@@ -1,0 +1,9 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Application
+metadata:
+  name: osde2e
+spec:
+  displayName: osde2e
+  description: >
+    A comprehensive test framework used for Service Delivery to test all
+    aspects of Managed OpenShift Clusters

--- a/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/component.yaml
+++ b/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/component.yaml
@@ -1,0 +1,15 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  name: osde2e-main
+  annotations:
+    build.appstudio.openshift.io/request: configure-pac
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build","bundle":"latest"}'
+spec:
+  application: osde2e
+  componentName: osde2e-main
+  source:
+    git:
+      dockerfileUrl: Dockerfile.osde2e
+      revision: main
+      url: https://github.com/openshift/osde2e

--- a/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/image_repository.yaml
+++ b/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/image_repository.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ImageRepository
+metadata:
+  annotations:
+    image-controller.appstudio.redhat.com/update-component-image: true
+  name: imagerepository-for-osde2e-osde2e-main
+  labels:
+    appstudio.redhat.com/application: osde2e
+    appstudio.redhat.com/component: osde2e-main
+spec:
+  image:
+    name: osde2e/osde2e-main
+    visibility: public

--- a/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/integration_test_scenario.yaml
@@ -2,7 +2,6 @@ apiVersion: appstudio.redhat.com/v1beta2
 kind: IntegrationTestScenario
 metadata:
   name: osde2e-enterprise-contract
-  namespace: osde2e-cicada-tenant
 spec:
   params:
     - name: POLICY_CONFIGURATION

--- a/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/kustomization.yaml
@@ -1,5 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: osde2e-cicada-tenant
 resources:
+- application.yaml
+- component.yaml
+- image_repository.yaml
 - integration_test_scenario.yaml
 - release_plan.yaml

--- a/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/osde2e-cicada-tenant/release_plan.yaml
@@ -2,7 +2,6 @@ apiVersion: appstudio.redhat.com/v1alpha1
 kind: ReleasePlan
 metadata:
   name: osde2e-release-as-service
-  namespace: osde2e-cicada-tenant
   labels:
     release.appstudio.openshift.io/auto-release: 'true'
     release.appstudio.openshift.io/standing-attribution: 'true'


### PR DESCRIPTION
add the application and component for osde2e to be fully onboarded onto
the casc model. These resources exist already, so hopefully argocd
adopts them properly

Signed-off-by: Brady Pratt <bpratt@redhat.com>
