### PR TITLE
MULTIARCH-4784: Multi-version configuration for the multiarch-tuning-operator FBC

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/projctl.konflux.dev_v1beta1_project_file-based-catalog.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/projctl.konflux.dev_v1beta1_project_file-based-catalog.yaml
@@ -1,0 +1,10 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: Project
+metadata:
+  name: file-based-catalog
+  namespace: multiarch-tuning-ope-tenant
+spec:
+  description: |
+    Multi-version project for the file-based catalog of the Multiarch Tuning Operator
+  displayName: Multi-version project for the file-based catalog of the Multiarch Tuning
+    Operator

--- a/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/projctl.konflux.dev_v1beta1_projectdevelopmentstream_file-based-catalog-v4-16.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/projctl.konflux.dev_v1beta1_projectdevelopmentstream_file-based-catalog-v4-16.yaml
@@ -1,0 +1,14 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStream
+metadata:
+  name: file-based-catalog-v4-16
+  namespace: multiarch-tuning-ope-tenant
+spec:
+  project: file-based-catalog
+  template:
+    name: file-based-catalog
+    values:
+    - name: version
+      value: "4.17"
+    - name: versionName
+      value: v4-17

--- a/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/projctl.konflux.dev_v1beta1_projectdevelopmentstreamtemplate_file-based-catalog.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/projctl.konflux.dev_v1beta1_projectdevelopmentstreamtemplate_file-based-catalog.yaml
@@ -1,0 +1,57 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStreamTemplate
+metadata:
+  name: file-based-catalog
+  namespace: multiarch-tuning-ope-tenant
+spec:
+  project: file-based-catalog
+  resources:
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Application
+    metadata:
+      annotations:
+        application.thumbnail: "6"
+        finalizeCount: "0"
+      finalizers:
+      - spi.appstudio.redhat.com/remote-secrets
+      name: fbc-{{.versionName}}
+    spec:
+      appModelRepository:
+        url: ""
+      displayName: fbc-{{.versionName}}
+      gitOpsRepository:
+        url: ""
+  - apiVersion: appstudio.redhat.com/v1alpha1
+    kind: Component
+    metadata:
+      annotations:
+        applicationFailCounter: "0"
+        build.appstudio.openshift.io/pipeline: '{"name":"fbc-builder","bundle":"latest"}'
+      finalizers:
+      - test.appstudio.openshift.io/component
+      - image-controller.appstudio.openshift.io/image-repository
+      - image-registry-secret-sa-link.component.appstudio.openshift.io/finalizer
+      - pac.component.appstudio.openshift.io/finalizer
+      name: fbc-v4-16
+      namespace: multiarch-tuning-ope-tenant
+    spec:
+      application: fbc-{{.versionName}}
+      componentName: fbc-{{.versionName}}
+      replicas: 0
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+      source:
+        git:
+          context: ./
+          devfileUrl: https://raw.githubusercontent.com/openshift/multiarch-tuning-operator/fbc-4.16/devfile.yaml
+          revision: fbc-{{.version}}
+          url: https://github.com/openshift/multiarch-tuning-operator
+      targetPort: 50051
+  variables:
+  - description: A version number for a new OCP stream
+    name: version
+  - description: |
+      The name of some objects cannot include dots. It's recommended to set this versionName replacing any `.` with hyphen (`-`) in the value of the parameter `version`.
+    name: versionName

--- a/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/kustomization.yaml
@@ -1,4 +1,8 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 # Naming: <API_GROUP>/<KIND_PLURAL>/<METADATA_NAME>
-resources: []
+resources:
+  - projectl.konflux.dev/projects/file-based-catalog
+  - projectl.konflux.dev/projectdevelopmentstreamtemplates/file-based-catalog
+  - projectl.konflux.dev/projectdevelopmentstreams/file-based-catalog-v4-16
+

--- a/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projectdevelopmentstreams/file-based-catalog-v4-16/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projectdevelopmentstreams/file-based-catalog-v4-16/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - ./projectdevelopmentstream.yaml

--- a/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projectdevelopmentstreams/file-based-catalog-v4-16/projectdevelopmentstream.yaml
+++ b/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projectdevelopmentstreams/file-based-catalog-v4-16/projectdevelopmentstream.yaml
@@ -1,0 +1,13 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStream
+metadata:
+  name: file-based-catalog-v4-16
+spec:
+  project: file-based-catalog
+  template:
+    name: file-based-catalog
+    values:
+      - name: version
+        value: "4.17"
+      - name: versionName
+        value: "v4-17"

--- a/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projectdevelopmentstreamtemplates/file-based-catalog/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projectdevelopmentstreamtemplates/file-based-catalog/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - ./projectdevelopmentstreamtemplate.yaml

--- a/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projectdevelopmentstreamtemplates/file-based-catalog/projectdevelopmentstreamtemplate.yaml
+++ b/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projectdevelopmentstreamtemplates/file-based-catalog/projectdevelopmentstreamtemplate.yaml
@@ -1,0 +1,57 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStreamTemplate
+metadata:
+  name: file-based-catalog
+spec:
+  project: file-based-catalog
+  variables:
+    - name: version
+      description: A version number for a new OCP stream
+    - name: versionName
+      description: >
+        The name of some objects cannot include dots. It's recommended to set this versionName replacing any `.` with
+        hyphen (`-`) in the value of the parameter `version`.
+  resources:
+    - apiVersion: appstudio.redhat.com/v1alpha1
+      kind: Application
+      metadata:
+        annotations:
+          application.thumbnail: "6"
+          finalizeCount: "0"
+        finalizers:
+          - spi.appstudio.redhat.com/remote-secrets
+        name: "fbc-{{.versionName}}"
+      spec:
+        appModelRepository:
+          url: ""
+        displayName: "fbc-{{.versionName}}"
+        gitOpsRepository:
+          url: ""
+    - apiVersion: appstudio.redhat.com/v1alpha1
+      kind: Component
+      metadata:
+        annotations:
+          applicationFailCounter: "0"
+          build.appstudio.openshift.io/pipeline: '{"name":"fbc-builder","bundle":"latest"}'
+        finalizers:
+          - test.appstudio.openshift.io/component
+          - image-controller.appstudio.openshift.io/image-repository
+          - image-registry-secret-sa-link.component.appstudio.openshift.io/finalizer
+          - pac.component.appstudio.openshift.io/finalizer
+        name: fbc-v4-16
+        namespace: multiarch-tuning-ope-tenant
+      spec:
+        application: "fbc-{{.versionName}}"
+        componentName: "fbc-{{.versionName}}"
+        replicas: 0
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        source:
+          git:
+            context: ./
+            devfileUrl: https://raw.githubusercontent.com/openshift/multiarch-tuning-operator/fbc-4.16/devfile.yaml
+            revision: "fbc-{{.version}}"
+            url: https://github.com/openshift/multiarch-tuning-operator
+        targetPort: 50051

--- a/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projects/file-based-catalog/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projects/file-based-catalog/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - ./project.yaml

--- a/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projects/file-based-catalog/project.yaml
+++ b/cluster/stone-prd-rh01/tenants/multiarch-tuning-ope-tenant/_base/projectl.konflux.dev/projects/file-based-catalog/project.yaml
@@ -1,0 +1,8 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: Project
+metadata:
+  name: file-based-catalog
+spec:
+  displayName: Multi-version project for the file-based catalog of the Multiarch Tuning Operator
+  description: |
+    Multi-version project for the file-based catalog of the Multiarch Tuning Operator


### PR DESCRIPTION
This PR configure a multi-version project for the FBC of the multiarch-tuning-operator, starting from 4.17 and leaving 4.16 to the UI/manual creation