### PR TITLE
[orchestrator-releng] Use dedicated policy for IntegrationTestScenarios

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_helm-operator-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_helm-operator-enterprise-contract.yaml
@@ -10,7 +10,7 @@ spec:
     name: application
   params:
   - name: POLICY_CONFIGURATION
-    value: rhtap-releng-tenant/fbc-stage
+    value: rhtap-releng-tenant/registry-orchestrator-releng
   resolverRef:
     params:
     - name: url

--- a/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/integration_test_scenario.yaml
+++ b/cluster/stone-prd-rh01/tenants/orchestrator-releng-tenant/operator/integration_test_scenario.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   params:
     - name: POLICY_CONFIGURATION
-      value: rhtap-releng-tenant/fbc-stage
+      value: rhtap-releng-tenant/registry-orchestrator-releng
   application: helm-operator
   contexts:
     - description: Application testing


### PR DESCRIPTION
Use dedicated policy for building the orchestrator's operator container images