### PR TITLE
Create payload-tracker-frontend release plan

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1alpha1_releaseplan_payload-tracker-frontend-release-as-ms.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/appstudio.redhat.com_v1alpha1_releaseplan_payload-tracker-frontend-release-as-ms.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: payload-tracker-frontend-release-as-ms
+  namespace: hcc-pipeline-tenant
+spec:
+  application: payload-tracker-frontend
+  displayName: payload-tracker-frontend release-to-quay
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - payload-tracker-frontend_release_plan.yaml
   - integration_test_scenario.yaml              #Ingress
   - integration_test_tekton.yaml                #Ingress
   - release_plan.yaml                           #Ingress

--- a/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/payload-tracker-frontend_release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/hcc-pipeline-tenant/payload-tracker-frontend_release_plan.yaml
@@ -1,0 +1,12 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: payload-tracker-frontend-release-as-ms
+  namespace: hcc-pipeline-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  application: payload-tracker-frontend
+  displayName: payload-tracker-frontend release-to-quay
+  target: rhtap-releng-tenant


### PR DESCRIPTION
Part of [RHCLOUD-32758](https://issues.redhat.com/browse/RHCLOUD-32758)

Added release plan for payload-tracker-frontend

cc @scoheb @gbenhaim