### PR TITLE
[RHCLOUD-30197] Add quickstarts-enterprise-contract and bonfire integration

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_quickstarts-bonfire-tekton.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/appstudio.redhat.com_v1beta1_integrationtestscenario_quickstarts-bonfire-tekton.yaml
@@ -1,0 +1,25 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "false"
+  name: quickstarts-bonfire-tekton
+  namespace: console-platex-services-tenant
+spec:
+  application: quickstarts
+  params:
+  - name: APP_NAME
+    value: quickstarts
+  - name: COMPONENTS
+    value: quickstarts
+  - name: COMPONENT_NAME
+    value: quickstarts
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/basic.yaml
+    resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_quickstarts-enterprise-contract.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/appstudio.redhat.com_v1beta2_integrationtestscenario_quickstarts-enterprise-contract.yaml
@@ -1,0 +1,22 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: quickstarts-enterprise-contract
+  namespace: console-platex-services-tenant
+spec:
+  application: quickstarts
+  contexts:
+  - description: Application testing
+    name: application
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/tmp-onboard-policy
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/build-definitions
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract.yaml
+    resolver: git

--- a/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/external-secrets.io_v1beta1_externalsecret_app-interface.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: app-interface
+  namespace: console-platex-services-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: production/redhat/app-interface
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: app-interface

--- a/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/external-secrets.io_v1beta1_externalsecret_consoledot-ephemeral-env-provider.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: consoledot-ephemeral-env-provider
+  namespace: console-platex-services-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: production/redhat/consoledot-ephemeral-env-provider
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault-rh-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ephemeral-env-provider

--- a/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/external-secrets.io_v1beta1_externalsecret_rh-artifacts-bucket-writer.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: rh-artifacts-bucket-writer
+  namespace: console-platex-services-tenant
+spec:
+  dataFrom:
+  - extract:
+      key: ""
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: rh-artifacts-bucket-writer-secret-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rh-artifacts-bucket

--- a/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/kustomization.yaml
+++ b/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/kustomization.yaml
@@ -1,5 +1,9 @@
+---
 resources:
 - integration_test_scenario.yaml
-
+- quickstarts-integration.yaml
+- quickstarts-bonfire-tekton.yaml
+- ../../../../lib/consoledot-test-pipeline
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: console-platex-services-tenant

--- a/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/quickstarts-bonfire-tekton.yaml
+++ b/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/quickstarts-bonfire-tekton.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: appstudio.redhat.com/v1beta1
+kind: IntegrationTestScenario
+metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "false" # Change to "true" if you don't need the test to be mandatory
+  name: quickstarts-bonfire-tekton
+  namespace: console-platex-services-tenant
+spec:
+  application: quickstarts
+  resolverRef:
+    params:
+    - name: url
+      value: https://github.com/RedHatInsights/bonfire-tekton.git
+    - name: revision
+      value: main # Or whatever branch you want to test
+    - name: pathInRepo
+      value: pipelines/basic.yaml # This is the path to the pipeline
+    resolver: git
+  params:
+  - name: APP_NAME
+    value: quickstarts
+  - name: COMPONENTS
+    value: quickstarts
+  - name: COMPONENT_NAME
+    value: quickstarts
+

--- a/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/quickstarts-integration.yaml
+++ b/cluster/stone-prd-rh01/tenants/console-platex-services-tenant/quickstarts-integration.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: quickstarts-enterprise-contract
+  namespace: console-platex-services-tenant
+spec:
+  params:
+  - name: POLICY_CONFIGURATION
+    value: rhtap-releng-tenant/tmp-onboard-policy
+  application: quickstarts
+  contexts:
+  - description: Application testing
+    name: application
+  resolverRef:
+    params:
+    - name: url
+      value: 'https://github.com/redhat-appstudio/build-definitions'
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/enterprise-contract.yaml
+    resolver: git


### PR DESCRIPTION
Enable enterprise contract for [quickstarts api](https://github.com/RedHatInsights/quickstarts)