### PR TITLE
chore: onboard release-service-monitor to Konflux

### DIFF
--- a/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-service-monitor-release-to-quay-rhtap-ser.yaml
+++ b/auto-generated/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/appstudio.redhat.com_v1alpha1_releaseplan_release-service-monitor-release-to-quay-rhtap-ser.yaml
@@ -1,0 +1,11 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "true"
+    release.appstudio.openshift.io/standing-attribution: "true"
+  name: release-service-monitor-release-to-quay-rhtap-ser
+  namespace: rhtap-release-2-tenant
+spec:
+  application: release-service-monitor
+  target: rhtap-releng-tenant

--- a/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/release_plan.yaml
+++ b/cluster/stone-prd-rh01/tenants/rhtap-release-2-tenant/release_plan.yaml
@@ -21,3 +21,15 @@ metadata:
 spec:
   application: internal-services
   target: rhtap-releng-tenant
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  name: release-service-monitor-release-to-quay-rhtap-ser
+  namespace: rhtap-release-2-tenant
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+spec:
+  application: release-service-monitor
+  target: rhtap-releng-tenant


### PR DESCRIPTION
This commit adds the RP for release-service-monitor to Konflux to release the application.